### PR TITLE
use O_NONBLOCK instead of 0x800

### DIFF
--- a/poller_epoll.go
+++ b/poller_epoll.go
@@ -270,7 +270,7 @@ func newPoller(g *Gopher, isListener bool, index int) (*poller, error) {
 	}
 
 	// EFD_NONBLOCK = 0x800
-	r0, _, e0 := syscall.Syscall(syscall.SYS_EVENTFD2, 0, 0x800, 0)
+	r0, _, e0 := syscall.Syscall(syscall.SYS_EVENTFD2, 0, syscall.O_NONBLOCK, 0)
 	if e0 != 0 {
 		syscall.Close(fd)
 		return nil, err


### PR DESCRIPTION
`EFD_NONBLOCK` Set the`O_NONBLOCK` file status flag on the open file description.