### PR TITLE
removed unused variables and allow OnMessage to not be set

### DIFF
--- a/examples/websocket/client/client.go
+++ b/examples/websocket/client/client.go
@@ -65,7 +65,7 @@ func main() {
 				return
 			}
 			if receiveType != websocket.TextMessage {
-				log.Println("received type != websocket.TextMessage")
+				log.Printf("received type(%d) != websocket.TextMessage(%d)\n", receiveType, websocket.TextMessage)
 				return
 
 			}

--- a/nbhttp/client.go
+++ b/nbhttp/client.go
@@ -19,8 +19,7 @@ import (
 type Client struct {
 	mux sync.Mutex
 
-	Conn  *httpConn
-	conns map[*httpConn]struct{}
+	Conn *httpConn
 
 	Engine *Engine
 

--- a/nbhttp/httpconn.go
+++ b/nbhttp/httpconn.go
@@ -24,7 +24,6 @@ type httpConn struct {
 	cli      *Client
 	conn     net.Conn
 	handlers []resHandler
-	executor func(f func())
 
 	closed bool
 


### PR DESCRIPTION
- remove unused variables
- do not panic if OnMessage handler is not set
- If not using OnMessage handler, full Websocket message should not be buffered