### PR TITLE
 support both tls/non-tls together

### DIFF
--- a/examples/http/nbclient/client.go
+++ b/examples/http/nbclient/client.go
@@ -23,9 +23,7 @@ var (
 func main() {
 	flag.Parse()
 
-	engine := nbhttp.NewEngine(nbhttp.Config{
-		SupportClient: true,
-	})
+	engine := nbhttp.NewEngine(nbhttp.Config{})
 
 	err := engine.Start()
 	if err != nil {

--- a/examples/http/nbclient/client.go
+++ b/examples/http/nbclient/client.go
@@ -23,7 +23,7 @@ var (
 func main() {
 	flag.Parse()
 
-	engine := nbhttp.NewEngineTLS(nbhttp.Config{
+	engine := nbhttp.NewEngine(nbhttp.Config{
 		SupportClient: true,
 	})
 

--- a/examples/http/server/server.go
+++ b/examples/http/server/server.go
@@ -35,7 +35,8 @@ func main() {
 	svr := nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{"localhost:8888"},
-	}, mux, nil) // pool.Go)
+		Handler: mux,
+	}) // pool.Go)
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/http/server_tls/server.go
+++ b/examples/http/server_tls/server.go
@@ -44,9 +44,11 @@ func main() {
 	mux.HandleFunc("/echo", onEcho)
 
 	svr := nbhttp.NewServer(nbhttp.Config{
-		Network:  "tcp",
-		AddrsTLS: []nbhttp.ConfTLSAddr{{Addrs: []string{"localhost:8888"}, TLSConfig: tlsConfig}},
-	}, mux, nil)
+		Network:   "tcp",
+		AddrsTLS:  []string{"localhost:8888"},
+		TLSConfig: tlsConfig,
+		Handler:   mux,
+	})
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/http/server_tls/server.go
+++ b/examples/http/server_tls/server.go
@@ -43,10 +43,10 @@ func main() {
 	mux := &http.ServeMux{}
 	mux.HandleFunc("/echo", onEcho)
 
-	svr := nbhttp.NewServerTLS(nbhttp.Config{
-		Network: "tcp",
-		Addrs:   []string{"localhost:8888"},
-	}, mux, nil, tlsConfig)
+	svr := nbhttp.NewServer(nbhttp.Config{
+		Network:  "tcp",
+		AddrsTLS: []nbhttp.ConfTLSAddr{{Addrs: []string{"localhost:8888"}, TLSConfig: tlsConfig}},
+	}, mux, nil)
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/http_1m/server/server.go
+++ b/examples/http_1m/server/server.go
@@ -41,7 +41,8 @@ func main() {
 		Addrs:   addrs,
 		MaxLoad: 1000000,
 		NPoller: runtime.NumCPU() * 2,
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/http_trailer/server/server.go
+++ b/examples/http_trailer/server/server.go
@@ -50,7 +50,8 @@ func main() {
 	svr := nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{"localhost:8888"},
-	}, mux, nil) // pool.Go)
+		Handler: mux,
+	}) // pool.Go)
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/shutdown/server.go
+++ b/examples/shutdown/server.go
@@ -29,7 +29,8 @@ func main() {
 		Addrs:   []string{"localhost:8888"},
 		MaxLoad: 1000000,
 		NPoller: runtime.NumCPU() * 2,
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/websocket/client/client.go
+++ b/examples/websocket/client/client.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"time"
@@ -14,9 +15,10 @@ func main() {
 	flag.Parse()
 
 	u := url.URL{Scheme: "ws", Host: "localhost:8888", Path: "/ws"}
-	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	c, res, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
-		log.Fatal("dial:", err)
+		bReason, _ := io.ReadAll(res.Body)
+		log.Fatalf("dial: %v, reason: %v\n", err, string(bReason))
 	}
 	defer c.Close()
 

--- a/examples/websocket/data_uploader/server/server.go
+++ b/examples/websocket/data_uploader/server/server.go
@@ -86,7 +86,8 @@ func main() {
 	svr := nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{"localhost:8888"},
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/websocket/nbioclient/client.go
+++ b/examples/websocket/nbioclient/client.go
@@ -31,9 +31,7 @@ func newUpgrader() *websocket.Upgrader {
 }
 
 func main() {
-	engine := nbhttp.NewEngine(nbhttp.Config{
-		SupportClient: true,
-	})
+	engine := nbhttp.NewEngine(nbhttp.Config{})
 	err := engine.Start()
 	if err != nil {
 		fmt.Printf("nbio.Start failed: %v\n", err)

--- a/examples/websocket/nbioclient/client.go
+++ b/examples/websocket/nbioclient/client.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -45,9 +46,11 @@ func main() {
 			Upgrader:    newUpgrader(),
 			DialTimeout: time.Second * 3,
 		}
-		c, _, err := dialer.Dial(u.String(), nil)
+		c, res, err := dialer.Dial(u.String(), nil)
 		if err != nil {
-			panic(fmt.Errorf("dial: %v", err))
+			bReason, _ := io.ReadAll(res.Body)
+			fmt.Printf("dial: %v, reason: %v\n", err, string(bReason))
+			return
 		}
 		c.WriteMessage(websocket.TextMessage, []byte("hello"))
 	}

--- a/examples/websocket/server/server.go
+++ b/examples/websocket/server/server.go
@@ -55,7 +55,8 @@ func main() {
 	svr := nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{"localhost:8888"},
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/websocket/server_autobahn/server.go
+++ b/examples/websocket/server_autobahn/server.go
@@ -76,11 +76,11 @@ func main() {
 	log.Printf("calling new server tls\n")
 
 	messageHandlerExecutePool := taskpool.NewFixedPool(100, 1000)
-	svrTLS := nbhttp.NewServerTLS(nbhttp.Config{
+	svrTLS := nbhttp.NewServer(nbhttp.Config{
 		Network:        "tcp",
-		Addrs:          []string{"localhost:9999"},
+		AddrsTLS:[]nbhttp.ConfTLSAddr{{Addrs:[]string{"localhost:9999"},TLSConfig:tlsConfig}},
 		ReadBufferSize: 1024 * 1024,
-	}, mux, messageHandlerExecutePool.Go, tlsConfig)
+	}, mux, messageHandlerExecutePool.Go)
 	svr := nbhttp.NewServer(nbhttp.Config{
 		Network:        "tcp",
 		Addrs:          []string{"localhost:9998"},

--- a/examples/websocket/server_autobahn/server.go
+++ b/examples/websocket/server_autobahn/server.go
@@ -78,14 +78,19 @@ func main() {
 	messageHandlerExecutePool := taskpool.NewFixedPool(100, 1000)
 	svrTLS := nbhttp.NewServer(nbhttp.Config{
 		Network:        "tcp",
-		AddrsTLS:[]nbhttp.ConfTLSAddr{{Addrs:[]string{"localhost:9999"},TLSConfig:tlsConfig}},
+		AddrsTLS:       []string{"localhost:9999"},
+		TLSConfig:      tlsConfig,
 		ReadBufferSize: 1024 * 1024,
-	}, mux, messageHandlerExecutePool.Go)
+		Handler:        mux,
+		ServerExecutor: messageHandlerExecutePool.Go,
+	})
 	svr := nbhttp.NewServer(nbhttp.Config{
 		Network:        "tcp",
 		Addrs:          []string{"localhost:9998"},
 		ReadBufferSize: 1024 * 1024,
-	}, mux, messageHandlerExecutePool.Go)
+		Handler:        mux,
+		ServerExecutor: messageHandlerExecutePool.Go,
+	})
 
 	log.Printf("calling start non-tls\n")
 	err = svr.Start()

--- a/examples/websocket/server_keepalive/server.go
+++ b/examples/websocket/server_keepalive/server.go
@@ -88,7 +88,8 @@ func main() {
 	server = nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{"localhost:8888"},
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := server.Start()
 	if err != nil {

--- a/examples/websocket/server_keepalive2/server.go
+++ b/examples/websocket/server_keepalive2/server.go
@@ -118,7 +118,8 @@ func main() {
 	svr := nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{"localhost:8888"},
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/websocket/server_manual_frame_assembly/server.go
+++ b/examples/websocket/server_manual_frame_assembly/server.go
@@ -9,9 +9,9 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/lesismal/nbio/examples/fixedbufferpool"
 	"github.com/lesismal/nbio/nbhttp"
 	"github.com/lesismal/nbio/nbhttp/websocket"
-	"github.com/lesismal/nbio/examples/fixedbufferpool"
 )
 
 var (
@@ -83,7 +83,8 @@ func main() {
 		Network:                 "tcp",
 		Addrs:                   []string{"localhost:8888"},
 		ReleaseWebsocketPayload: true,
-	}, mux, nil)
+		Handler:                 mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/websocket/server_sticky/server.go
+++ b/examples/websocket/server_sticky/server.go
@@ -47,7 +47,8 @@ func main() {
 	svr = nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{"localhost:28001"},
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/websocket/test_websocket/websocket_test.go
+++ b/examples/websocket/test_websocket/websocket_test.go
@@ -53,7 +53,8 @@ func server(ctx context.Context, cancelFunc context.CancelFunc, readCount int) {
 	svr = nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{*addr},
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/websocket_1m/nbioclient/client.go
+++ b/examples/websocket_1m/nbioclient/client.go
@@ -69,7 +69,7 @@ func newUpgrader() *websocket.Upgrader {
 func main() {
 	flag.Parse()
 
-	engine := nbhttp.NewEngineTLS(nbhttp.Config{
+	engine := nbhttp.NewEngine(nbhttp.Config{
 		SupportClient: true,
 	})
 	err := engine.Start()

--- a/examples/websocket_1m/nbioclient/client.go
+++ b/examples/websocket_1m/nbioclient/client.go
@@ -69,9 +69,7 @@ func newUpgrader() *websocket.Upgrader {
 func main() {
 	flag.Parse()
 
-	engine := nbhttp.NewEngine(nbhttp.Config{
-		SupportClient: true,
-	})
+	engine := nbhttp.NewEngine(nbhttp.Config{})
 	err := engine.Start()
 	if err != nil {
 		fmt.Printf("nbio.Start failed: %v\n", err)

--- a/examples/websocket_1m/server/server.go
+++ b/examples/websocket_1m/server/server.go
@@ -46,7 +46,8 @@ func main() {
 		Addrs:                   addrs,
 		MaxLoad:                 1000000,
 		ReleaseWebsocketPayload: true,
-	}, mux, nil)
+		Handler:                 mux,
+	})
 
 	err := svr.Start()
 	if err != nil {

--- a/examples/websocket_1m_tls/nbioclient/client.go
+++ b/examples/websocket_1m_tls/nbioclient/client.go
@@ -69,7 +69,7 @@ func newUpgrader() *websocket.Upgrader {
 func main() {
 	flag.Parse()
 
-	engine := nbhttp.NewEngineTLS(nbhttp.Config{
+	engine := nbhttp.NewEngine(nbhttp.Config{
 		SupportClient: true,
 	})
 	err := engine.Start()

--- a/examples/websocket_1m_tls/nbioclient/client.go
+++ b/examples/websocket_1m_tls/nbioclient/client.go
@@ -69,9 +69,7 @@ func newUpgrader() *websocket.Upgrader {
 func main() {
 	flag.Parse()
 
-	engine := nbhttp.NewEngine(nbhttp.Config{
-		SupportClient: true,
-	})
+	engine := nbhttp.NewEngine(nbhttp.Config{})
 	err := engine.Start()
 	if err != nil {
 		fmt.Printf("nbio.Start failed: %v\n", err)

--- a/examples/websocket_1m_tls/server/server.go
+++ b/examples/websocket_1m_tls/server/server.go
@@ -63,10 +63,12 @@ func main() {
 
 	svr = nbhttp.NewServer(nbhttp.Config{
 		Network:                 "tcp",
-		AddrsTLS:                []nbhttp.ConfTLSAddr{{addrs, tlsConfig}},
+		AddrsTLS:                addrs,
+		TLSConfig:               tlsConfig,
 		MaxLoad:                 1000000,
 		ReleaseWebsocketPayload: true,
-	}, mux, nil)
+		Handler:                 mux,
+	})
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_1m_tls/server/server.go
+++ b/examples/websocket_1m_tls/server/server.go
@@ -61,12 +61,12 @@ func main() {
 	mux := &http.ServeMux{}
 	mux.HandleFunc("/wss", onWebsocket)
 
-	svr = nbhttp.NewServerTLS(nbhttp.Config{
+	svr = nbhttp.NewServer(nbhttp.Config{
 		Network:                 "tcp",
-		Addrs:                   addrs,
+		AddrsTLS:                []nbhttp.ConfTLSAddr{{addrs, tlsConfig}},
 		MaxLoad:                 1000000,
 		ReleaseWebsocketPayload: true,
-	}, mux, nil, tlsConfig)
+	}, mux, nil)
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_both_tls_nontls/client/client.go
+++ b/examples/websocket_both_tls_nontls/client/client.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/tls"
+	"log"
+	"net/url"
+
+	"github.com/gorilla/websocket"
+)
+
+var (
+	addrNonTLS = "localhost:8080"
+	addrTLS    = "localhost:8443"
+)
+
+func main() {
+	clientNonTLS()
+	clientTLS()
+}
+
+func clientNonTLS() {
+	u := url.URL{Scheme: "ws", Host: addrNonTLS, Path: "/ws"}
+	log.Printf("connecting to %s", u.String())
+
+	dialer := &websocket.Dialer{}
+
+	c, _, err := dialer.Dial(u.String(), nil)
+	if err != nil {
+		log.Fatal("dial:", err)
+	}
+	defer c.Close()
+
+	for i := 0; i < 3; i++ {
+		echo(addrNonTLS, c, websocket.TextMessage)
+		echo(addrNonTLS, c, websocket.BinaryMessage)
+	}
+}
+
+func clientTLS() {
+	u := url.URL{Scheme: "wss", Host: addrTLS, Path: "/wss"}
+	log.Printf("connecting to %s", u.String())
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	dialer := &websocket.Dialer{
+		TLSClientConfig: tlsConfig,
+	}
+
+	c, _, err := dialer.Dial(u.String(), nil)
+	if err != nil {
+		log.Fatal("dial:", err)
+	}
+	defer c.Close()
+
+	for i := 0; i < 3; i++ {
+		echo(addrTLS, c, websocket.TextMessage)
+		echo(addrTLS, c, websocket.BinaryMessage)
+	}
+}
+
+func echo(addr string, c *websocket.Conn, messageType int) {
+	request := make([]byte, 1024)
+	if messageType == websocket.TextMessage {
+		for i := 0; i < len(request); i++ {
+			request[i] = 'a' + byte(i)%26
+		}
+	} else {
+		rand.Read(request)
+	}
+
+	err := c.WriteMessage(messageType, request)
+	if err != nil {
+		log.Fatalf("write: %v", err)
+		return
+	}
+
+	mt, response, err := c.ReadMessage()
+	if err != nil {
+		log.Panicf("ReadMessage failed: %v", err)
+	}
+	if mt != messageType {
+		log.Panicf("invalid response messageType: [%v != %v]", mt, messageType)
+	}
+	if !bytes.Equal(request, response) {
+		log.Panicf("invalid response: not equal")
+	}
+	log.Printf("echo to %v with message type [%v] success", addr, messageType)
+}

--- a/examples/websocket_both_tls_nontls/server/server.go
+++ b/examples/websocket_both_tls_nontls/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -13,15 +12,6 @@ import (
 	"github.com/lesismal/llib/std/crypto/tls"
 	"github.com/lesismal/nbio/nbhttp"
 	"github.com/lesismal/nbio/nbhttp/websocket"
-)
-
-var (
-	tlsConfig *tls.Config
-
-	tcpListener net.Listener
-	tlsListener net.Listener
-
-	engine *nbhttp.Engine
 )
 
 func newUpgrader() *websocket.Upgrader {
@@ -53,7 +43,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("tls.X509KeyPair failed: %v", err)
 	}
-	tlsConfig = &tls.Config{
+	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: true,
 	}
@@ -62,7 +52,7 @@ func main() {
 	mux.HandleFunc("/ws", onWebsocket)
 	mux.HandleFunc("/wss", onWebsocket)
 
-	engine = nbhttp.NewEngine(nbhttp.Config{
+	engine := nbhttp.NewEngine(nbhttp.Config{
 		Addrs:     []string{"localhost:8080"},
 		AddrsTLS:  []string{"localhost:8443"},
 		TLSConfig: tlsConfig,
@@ -78,14 +68,6 @@ func main() {
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
 	<-interrupt
-
-	if tcpListener != nil {
-		tcpListener.Close()
-	}
-
-	if tlsListener != nil {
-		tlsListener.Close()
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()

--- a/examples/websocket_both_tls_nontls/server/server.go
+++ b/examples/websocket_both_tls_nontls/server/server.go
@@ -92,7 +92,7 @@ func startServerTLS(addr string) {
 	}
 
 	logging.Info("Serve     TLS On: [%v]", addr)
-	tlsListener = tls.NewListener(ln, tlsConfig)
+	tlsListener = tls.NewListener(ln, tlsConfig, engine.TLSAllocator)
 	go func() {
 		defer ln.Close()
 		for {
@@ -131,7 +131,6 @@ func main() {
 		Handler:   mux,
 		TLSConfig: tlsConfig,
 	})
-	engine.InitTLSBuffers()
 
 	err = engine.Start()
 	if err != nil {

--- a/examples/websocket_both_tls_nontls/server/server.go
+++ b/examples/websocket_both_tls_nontls/server/server.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/lesismal/llib/std/crypto/tls"
+	"github.com/lesismal/nbio"
+	"github.com/lesismal/nbio/logging"
+	"github.com/lesismal/nbio/nbhttp"
+	"github.com/lesismal/nbio/nbhttp/websocket"
+)
+
+var (
+	tlsConfig *tls.Config
+
+	tcpListener net.Listener
+	tlsListener net.Listener
+
+	engine *nbhttp.Engine
+)
+
+func newUpgrader() *websocket.Upgrader {
+	u := websocket.NewUpgrader()
+	u.OnMessage(func(c *websocket.Conn, messageType websocket.MessageType, data []byte) {
+		// echo
+		c.WriteMessage(messageType, data)
+		c.SetReadDeadline(time.Now().Add(nbhttp.DefaultKeepaliveTime))
+	})
+	u.OnClose(func(c *websocket.Conn, err error) {
+		fmt.Println("OnClose:", c.LocalAddr().String(), err)
+	})
+
+	return u
+}
+
+func onWebsocket(w http.ResponseWriter, r *http.Request) {
+	upgrader := newUpgrader()
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		panic(err)
+	}
+	wsConn := conn.(*websocket.Conn)
+	fmt.Println("OnOpen:", wsConn.LocalAddr().String(), r.URL.Path)
+}
+
+func startServerNonTLS(addr string) {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		panic(err)
+	}
+	tcpListener = ln
+
+	logging.Info("Serve NON-TLS On: [%v]", addr)
+	go func() {
+		defer tcpListener.Close()
+		for {
+			conn, err := tcpListener.Accept()
+			if err == nil {
+				nbc, err := nbio.NBConn(conn)
+				if err != nil {
+					conn.Close()
+					continue
+				}
+				engine.AddConnNonTLS(nbc)
+			} else {
+				var ne net.Error
+				if ok := errors.As(err, &ne); ok && ne.Temporary() {
+					logging.Error("Accept failed: temporary error, retrying...")
+					time.Sleep(time.Second / 20)
+				} else {
+					logging.Error("Accept failed: %v, exit...", err)
+					break
+				}
+			}
+		}
+	}()
+}
+
+func startServerTLS(addr string) {
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		panic(err)
+	}
+
+	logging.Info("Serve     TLS On: [%v]", addr)
+	tlsListener = tls.NewListener(ln, tlsConfig)
+	go func() {
+		defer ln.Close()
+		for {
+			conn, err := tlsListener.Accept()
+			if err == nil {
+				engine.AddConnTLS(conn.(*tls.Conn))
+			} else {
+				var ne net.Error
+				if ok := errors.As(err, &ne); ok && ne.Temporary() {
+					logging.Error("Accept failed: temporary error, retrying...")
+					time.Sleep(time.Second / 20)
+				} else {
+					logging.Error("Accept failed: %v, exit...", err)
+					break
+				}
+			}
+		}
+	}()
+}
+
+func main() {
+	cert, err := tls.X509KeyPair(rsaCertPEM, rsaKeyPEM)
+	if err != nil {
+		log.Fatalf("tls.X509KeyPair failed: %v", err)
+	}
+	tlsConfig = &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true,
+	}
+
+	mux := &http.ServeMux{}
+	mux.HandleFunc("/ws", onWebsocket)
+	mux.HandleFunc("/wss", onWebsocket)
+
+	engine = nbhttp.NewEngineTLS(nbhttp.Config{
+		Handler:   mux,
+		TLSConfig: tlsConfig,
+	})
+	engine.InitTLSBuffers()
+
+	err = engine.Start()
+	if err != nil {
+		fmt.Printf("nbio.Start failed: %v\n", err)
+		return
+	}
+
+	startServerNonTLS("localhost:8080")
+	startServerTLS("localhost:8443")
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+	<-interrupt
+
+	if tcpListener != nil {
+		tcpListener.Close()
+	}
+
+	if tlsListener != nil {
+		tlsListener.Close()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	engine.Shutdown(ctx)
+
+	log.Println("exit")
+}
+
+var rsaCertPEM = []byte(`-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUJeohtgk8nnt8ofratXJg7kUJsI4wDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDEyMDcwODIyNThaFw0zMDEy
+MDUwODIyNThaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCy+ZrIvwwiZv4bPmvKx/637ltZLwfgh3ouiEaTchGu
+IQltthkqINHxFBqqJg44TUGHWthlrq6moQuKnWNjIsEc6wSD1df43NWBLgdxbPP0
+x4tAH9pIJU7TQqbznjDBhzRbUjVXBIcn7bNknY2+5t784pPF9H1v7h8GqTWpNH9l
+cz/v+snoqm9HC+qlsFLa4A3X9l5v05F1uoBfUALlP6bWyjHAfctpiJkoB9Yw1TJa
+gpq7E50kfttwfKNkkAZIbib10HugkMoQJAs2EsGkje98druIl8IXmuvBIF6nZHuM
+lt3UIZjS9RwPPLXhRHt1P0mR7BoBcOjiHgtSEs7Wk+j7AgMBAAGjUzBRMB0GA1Ud
+DgQWBBQdheJv73XSOhgMQtkwdYPnfO02+TAfBgNVHSMEGDAWgBQdheJv73XSOhgM
+QtkwdYPnfO02+TAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBf
+SKVNMdmBpD9m53kCrguo9iKQqmhnI0WLkpdWszc/vBgtpOE5ENOfHGAufHZve871
+2fzTXrgR0TF6UZWsQOqCm5Oh3URsCdXWewVMKgJ3DCii6QJ0MnhSFt6+xZE9C6Hi
+WhcywgdR8t/JXKDam6miohW8Rum/IZo5HK9Jz/R9icKDGumcqoaPj/ONvY4EUwgB
+irKKB7YgFogBmCtgi30beLVkXgk0GEcAf19lHHtX2Pv/lh3m34li1C9eBm1ca3kk
+M2tcQtm1G89NROEjcG92cg+GX3GiWIjbI0jD1wnVy2LCOXMgOVbKfGfVKISFt0b1
+DNn00G8C6ttLoGU2snyk
+-----END CERTIFICATE-----
+`)
+
+var rsaKeyPEM = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAsvmayL8MImb+Gz5rysf+t+5bWS8H4Id6LohGk3IRriEJbbYZ
+KiDR8RQaqiYOOE1Bh1rYZa6upqELip1jYyLBHOsEg9XX+NzVgS4HcWzz9MeLQB/a
+SCVO00Km854wwYc0W1I1VwSHJ+2zZJ2Nvube/OKTxfR9b+4fBqk1qTR/ZXM/7/rJ
+6KpvRwvqpbBS2uAN1/Zeb9ORdbqAX1AC5T+m1soxwH3LaYiZKAfWMNUyWoKauxOd
+JH7bcHyjZJAGSG4m9dB7oJDKECQLNhLBpI3vfHa7iJfCF5rrwSBep2R7jJbd1CGY
+0vUcDzy14UR7dT9JkewaAXDo4h4LUhLO1pPo+wIDAQABAoIBAF6yWwekrlL1k7Xu
+jTI6J7hCUesaS1yt0iQUzuLtFBXCPS7jjuUPgIXCUWl9wUBhAC8SDjWe+6IGzAiH
+xjKKDQuz/iuTVjbDAeTb6exF7b6yZieDswdBVjfJqHR2Wu3LEBTRpo9oQesKhkTS
+aFF97rZ3XCD9f/FdWOU5Wr8wm8edFK0zGsZ2N6r57yf1N6ocKlGBLBZ0v1Sc5ShV
+1PVAxeephQvwL5DrOgkArnuAzwRXwJQG78L0aldWY2q6xABQZQb5+ml7H/kyytef
+i+uGo3jHKepVALHmdpCGr9Yv+yCElup+ekv6cPy8qcmMBqGMISL1i1FEONxLcKWp
+GEJi6QECgYEA3ZPGMdUm3f2spdHn3C+/+xskQpz6efiPYpnqFys2TZD7j5OOnpcP
+ftNokA5oEgETg9ExJQ8aOCykseDc/abHerYyGw6SQxmDbyBLmkZmp9O3iMv2N8Pb
+Nrn9kQKSr6LXZ3gXzlrDvvRoYUlfWuLSxF4b4PYifkA5AfsdiKkj+5sCgYEAzseF
+XDTRKHHJnzxZDDdHQcwA0G9agsNj64BGUEjsAGmDiDyqOZnIjDLRt0O2X3oiIE5S
+TXySSEiIkxjfErVJMumLaIwqVvlS4pYKdQo1dkM7Jbt8wKRQdleRXOPPN7msoEUk
+Ta9ZsftHVUknPqblz9Uthb5h+sRaxIaE1llqDiECgYATS4oHzuL6k9uT+Qpyzymt
+qThoIJljQ7TgxjxvVhD9gjGV2CikQM1Vov1JBigj4Toc0XuxGXaUC7cv0kAMSpi2
+Y+VLG+K6ux8J70sGHTlVRgeGfxRq2MBfLKUbGplBeDG/zeJs0tSW7VullSkblgL6
+nKNa3LQ2QEt2k7KHswryHwKBgENDxk8bY1q7wTHKiNEffk+aFD25q4DUHMH0JWti
+fVsY98+upFU+gG2S7oOmREJE0aser0lDl7Zp2fu34IEOdfRY4p+s0O0gB+Vrl5VB
+L+j7r9bzaX6lNQN6MvA7ryHahZxRQaD/xLbQHgFRXbHUyvdTyo4yQ1821qwNclLk
+HUrhAoGAUtjR3nPFR4TEHlpTSQQovS8QtGTnOi7s7EzzdPWmjHPATrdLhMA0ezPj
+Mr+u5TRncZBIzAZtButlh1AHnpN/qO3P0c0Rbdep3XBc/82JWO8qdb5QvAkxga3X
+BpA7MNLxiqss+rCbwf3NbWxEMiDQ2zRwVoafVFys7tjmv6t2Xck=
+-----END RSA PRIVATE KEY-----
+`)

--- a/examples/websocket_both_tls_nontls/server/server.go
+++ b/examples/websocket_both_tls_nontls/server/server.go
@@ -62,17 +62,16 @@ func main() {
 	mux.HandleFunc("/ws", onWebsocket)
 	mux.HandleFunc("/wss", onWebsocket)
 
-	engine = nbhttp.NewEngineTLS(nbhttp.Config{
+	engine = nbhttp.NewEngine(nbhttp.Config{
 		AddrsTLS: []nbhttp.ConfTLSAddr{
 			{
-				Addr:      "localhost:8443",
-				TLSConfig: nil,
+				Addrs:     []string{"localhost:8443"},
+				TLSConfig: tlsConfig,
 			},
 		},
-		AddrsNonTLS: []string{"localhost:8080"},
+		Addrs: []string{"localhost:8080"},
 
-		Handler:   mux,
-		TLSConfig: tlsConfig,
+		Handler: mux,
 	})
 
 	err = engine.Start()

--- a/examples/websocket_both_tls_nontls/server/server.go
+++ b/examples/websocket_both_tls_nontls/server/server.go
@@ -63,15 +63,10 @@ func main() {
 	mux.HandleFunc("/wss", onWebsocket)
 
 	engine = nbhttp.NewEngine(nbhttp.Config{
-		AddrsTLS: []nbhttp.ConfTLSAddr{
-			{
-				Addrs:     []string{"localhost:8443"},
-				TLSConfig: tlsConfig,
-			},
-		},
-		Addrs: []string{"localhost:8080"},
-
-		Handler: mux,
+		Addrs:     []string{"localhost:8080"},
+		AddrsTLS:  []string{"localhost:8443"},
+		TLSConfig: tlsConfig,
+		Handler:   mux,
 	})
 
 	err = engine.Start()

--- a/examples/websocket_proxy/proxy_server/server.go
+++ b/examples/websocket_proxy/proxy_server/server.go
@@ -84,9 +84,8 @@ func main() {
 	proxyServer = nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
 		Addrs:   []string{proxyServerAddr},
-
-		SupportClient: true,
-	}, mux, nil)
+		Handler: mux,
+	})
 
 	err := proxyServer.Start()
 	if err != nil {

--- a/examples/websocket_tls/nbioclient/client.go
+++ b/examples/websocket_tls/nbioclient/client.go
@@ -44,9 +44,7 @@ func newUpgrader() *websocket.Upgrader {
 
 func main() {
 	flag.Parse()
-	engine := nbhttp.NewEngine(nbhttp.Config{
-		SupportClient: true,
-	})
+	engine := nbhttp.NewEngine(nbhttp.Config{})
 	err := engine.Start()
 	if err != nil {
 		fmt.Printf("nbio.Start failed: %v\n", err)

--- a/examples/websocket_tls/nbioclient/client.go
+++ b/examples/websocket_tls/nbioclient/client.go
@@ -44,7 +44,7 @@ func newUpgrader() *websocket.Upgrader {
 
 func main() {
 	flag.Parse()
-	engine := nbhttp.NewEngineTLS(nbhttp.Config{
+	engine := nbhttp.NewEngine(nbhttp.Config{
 		SupportClient: true,
 	})
 	err := engine.Start()

--- a/examples/websocket_tls/server/server.go
+++ b/examples/websocket_tls/server/server.go
@@ -67,9 +67,11 @@ func main() {
 	mux.HandleFunc("/wss", onWebsocket)
 
 	svr = nbhttp.NewServer(nbhttp.Config{
-		Network: "tcp",
-		AddrsTLS:                  []nbhttp.ConfTLSAddr{{Addrs:[]string{"localhost:8888"},TLSConfig:tlsConfig}},
-	}, mux, nil)
+		Network:   "tcp",
+		AddrsTLS:  []string{"localhost:8888"},
+		TLSConfig: tlsConfig,
+		Handler:   mux,
+	})
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_tls/server/server.go
+++ b/examples/websocket_tls/server/server.go
@@ -66,10 +66,10 @@ func main() {
 	mux := &http.ServeMux{}
 	mux.HandleFunc("/wss", onWebsocket)
 
-	svr = nbhttp.NewServerTLS(nbhttp.Config{
+	svr = nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
-		Addrs:   []string{"localhost:8888"},
-	}, mux, nil, tlsConfig)
+		AddrsTLS:                  []nbhttp.ConfTLSAddr{{Addrs:[]string{"localhost:8888"},TLSConfig:tlsConfig}},
+	}, mux, nil)
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_tls/server_manual_frame_assembly/server.go
+++ b/examples/websocket_tls/server_manual_frame_assembly/server.go
@@ -97,11 +97,11 @@ func main() {
 	mux := &http.ServeMux{}
 	mux.HandleFunc("/wss", onWebsocket)
 
-	svr := nbhttp.NewServerTLS(nbhttp.Config{
+	svr := nbhttp.NewServer(nbhttp.Config{
 		Network:                 "tcp",
-		Addrs:                   []string{"localhost:8888"},
+		AddrsTLS:                  []nbhttp.ConfTLSAddr{{Addrs:[]string{"localhost:8888"},TLSConfig:tlsConfig}},
 		ReleaseWebsocketPayload: true,
-	}, mux, nil, tlsConfig)
+	}, mux, nil)
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_tls/server_manual_frame_assembly/server.go
+++ b/examples/websocket_tls/server_manual_frame_assembly/server.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/lesismal/llib/std/crypto/tls"
+	"github.com/lesismal/nbio/examples/fixedbufferpool"
 	"github.com/lesismal/nbio/nbhttp"
 	"github.com/lesismal/nbio/nbhttp/websocket"
-	"github.com/lesismal/nbio/examples/fixedbufferpool"
 )
 
 var (
@@ -99,9 +99,11 @@ func main() {
 
 	svr := nbhttp.NewServer(nbhttp.Config{
 		Network:                 "tcp",
-		AddrsTLS:                  []nbhttp.ConfTLSAddr{{Addrs:[]string{"localhost:8888"},TLSConfig:tlsConfig}},
+		AddrsTLS:                []string{"localhost:8888"},
+		TLSConfig:               tlsConfig,
 		ReleaseWebsocketPayload: true,
-	}, mux, nil)
+		Handler:                 mux,
+	})
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_tls/sticky/server/server.go
+++ b/examples/websocket_tls/sticky/server/server.go
@@ -58,9 +58,11 @@ func main() {
 	mux.HandleFunc("/wss", onWebsocket)
 
 	svr = nbhttp.NewServer(nbhttp.Config{
-		Network: "tcp",
-		AddrsTLS:[]nbhttp.ConfTLSAddr{{Addrs:[]string{"localhost:8888"},TLSConfig:tlsConfig}},
-	}, mux, nil)
+		Network:   "tcp",
+		AddrsTLS:  []string{"localhost:8888"},
+		TLSConfig: tlsConfig,
+		Handler:   mux,
+	})
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_tls/sticky/server/server.go
+++ b/examples/websocket_tls/sticky/server/server.go
@@ -57,10 +57,10 @@ func main() {
 	mux := &http.ServeMux{}
 	mux.HandleFunc("/wss", onWebsocket)
 
-	svr = nbhttp.NewServerTLS(nbhttp.Config{
+	svr = nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
-		Addrs:   []string{"localhost:9999"},
-	}, mux, nil, tlsConfig)
+		AddrsTLS:[]nbhttp.ConfTLSAddr{{Addrs:[]string{"localhost:8888"},TLSConfig:tlsConfig}},
+	}, mux, nil)
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_tls/test_tls_websocket/websocket_test.go
+++ b/examples/websocket_tls/test_tls_websocket/websocket_test.go
@@ -121,10 +121,10 @@ func server(ctx context.Context, cancelFunc context.CancelFunc, readCount int) {
 		onWebsocket(cancelFunc, readCount, w, r)
 	})
 
-	svr = nbhttp.NewServerTLS(nbhttp.Config{
+	svr = nbhttp.NewServer(nbhttp.Config{
 		Network: "tcp",
-		Addrs:   []string{*addr},
-	}, mux, nil, tlsConfig)
+		AddrsTLS:[]nbhttp.ConfTLSAddr{{Addrs:[]string{*addr},TLSConfig:tlsConfig}},
+	}, mux, nil)
 
 	err = svr.Start()
 	if err != nil {

--- a/examples/websocket_tls/test_tls_websocket/websocket_test.go
+++ b/examples/websocket_tls/test_tls_websocket/websocket_test.go
@@ -122,9 +122,11 @@ func server(ctx context.Context, cancelFunc context.CancelFunc, readCount int) {
 	})
 
 	svr = nbhttp.NewServer(nbhttp.Config{
-		Network: "tcp",
-		AddrsTLS:[]nbhttp.ConfTLSAddr{{Addrs:[]string{*addr},TLSConfig:tlsConfig}},
-	}, mux, nil)
+		Network:   "tcp",
+		AddrsTLS:  []string{*addr},
+		TLSConfig: tlsConfig,
+		Handler:   mux,
+	})
 
 	err = svr.Start()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/gorilla/websocket v1.4.2
-	github.com/lesismal/llib v1.1.1
+	github.com/lesismal/llib v1.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/lesismal/llib v1.1.1 h1:3677dPIXLc1PMI8jN6iZ4UZ1ewaodE5lI00MlWf+Ecs=
-github.com/lesismal/llib v1.1.1/go.mod h1:3vmCrIMrpkaoA3bDu/sI+J7EyEUMPbOvmAxb7PlzilM=
+github.com/lesismal/llib v1.1.2 h1:50ITwMXXh1OeSdLJMD83sD4hBso9qpCfpRSHy2AhKqc=
+github.com/lesismal/llib v1.1.2/go.mod h1:3vmCrIMrpkaoA3bDu/sI+J7EyEUMPbOvmAxb7PlzilM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 golang.org/x/crypto v0.0.0-20210513122933-cd7d49e622d5 h1:N6Jp/LCiEoIBX56BZSR2bepK5GtbSC2DDOYT742mMfE=
 golang.org/x/crypto v0.0.0-20210513122933-cd7d49e622d5/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=

--- a/nbhttp/engine.go
+++ b/nbhttp/engine.go
@@ -354,6 +354,7 @@ func (e *Engine) TLSDataHandler(c *nbio.Conn, data []byte) {
 	}
 }
 
+// ServerOnOpen .
 func (engine *Engine) ServerOnOpen(c *nbio.Conn) {
 	if c.Session() != nil {
 		return
@@ -376,6 +377,7 @@ func (engine *Engine) ServerOnOpen(c *nbio.Conn) {
 	c.OnData(engine.DataHandler)
 }
 
+// AddConnNonTLS .
 func (engine *Engine) AddConnNonTLS(c net.Conn) {
 	nbc, err := nbio.NBConn(c)
 	if err != nil {
@@ -404,6 +406,7 @@ func (engine *Engine) AddConnNonTLS(c net.Conn) {
 	nbc.SetReadDeadline(time.Now().Add(engine.KeepaliveTime))
 }
 
+// ServerOnOpenTLS .
 func (engine *Engine) ServerOnOpenTLS(c *nbio.Conn) {
 	if c.Session() != nil {
 		return
@@ -431,6 +434,7 @@ func (engine *Engine) ServerOnOpenTLS(c *nbio.Conn) {
 	c.OnData(engine.TLSDataHandler)
 }
 
+// AddConnTLS .
 func (engine *Engine) AddConnTLS(tlsConn *tls.Conn) {
 	nbc, err := nbio.NBConn(tlsConn.Conn())
 	if err != nil {

--- a/nbhttp/engine.go
+++ b/nbhttp/engine.go
@@ -450,8 +450,8 @@ func (engine *Engine) AddConnTLS(tlsConn *tls.Conn) {
 	engine.mux.Unlock()
 	engine._onOpen(nbc)
 
-	isClient := false
-	tlsConn = tls.NewConn(nbc, engine.TLSConfig(), isClient, true, engine.TLSAllocator)
+	isNonBlock := true
+	tlsConn.ResetConn(nbc, isNonBlock)
 	processor := NewServerProcessor(tlsConn, engine.Handler, engine.KeepaliveTime, engine.EnableSendfile)
 	parser := NewParser(processor, false, engine.ReadLimit, nbc.Execute)
 	parser.Conn = tlsConn

--- a/nbhttp/processor.go
+++ b/nbhttp/processor.go
@@ -16,9 +16,8 @@ import (
 )
 
 var (
-	emptyRequest     = http.Request{}
-	emptyResponse    = Response{}
-	emptyStdResponse = http.Response{}
+	emptyRequest  = http.Request{}
+	emptyResponse = Response{}
 
 	requestPool = sync.Pool{
 		New: func() interface{} {
@@ -31,18 +30,6 @@ var (
 			return &Response{}
 		},
 	}
-
-	stdResponsePool = sync.Pool{
-		New: func() interface{} {
-			return &http.Response{}
-		},
-	}
-
-	// serverProcessorPool = sync.Pool{
-	// 	New: func() interface{} {
-	// 		return &ServerProcessor{}
-	// 	},
-	// }.
 )
 
 func releaseRequest(req *http.Request) {
@@ -65,12 +52,12 @@ func releaseResponse(res *Response) {
 	}
 }
 
-func releaseStdResponse(res *http.Response) {
-	if res != nil {
-		*res = emptyStdResponse
-		stdResponsePool.Put(res)
-	}
-}
+// func releaseStdResponse(res *http.Response) {
+// 	if res != nil {
+// 		*res = emptyStdResponse
+// 		stdResponsePool.Put(res)
+// 	}
+// }
 
 // Processor .
 type Processor interface {
@@ -329,7 +316,7 @@ func (p *ClientProcessor) OnProto(proto string) error {
 		// 	Proto:  proto,
 		// 	Header: http.Header{},
 		// }
-		p.response = stdResponsePool.Get().(*http.Response)
+		p.response = &http.Response{}
 		p.response.Proto = proto
 		p.response.Header = http.Header{}
 	} else {
@@ -379,7 +366,6 @@ func (p *ClientProcessor) OnComplete(parser *Parser) {
 	p.response = nil
 	parser.Execute(func() {
 		p.handler(res, nil)
-		releaseStdResponse(res)
 	})
 }
 

--- a/nbhttp/server.go
+++ b/nbhttp/server.go
@@ -6,8 +6,6 @@ package nbhttp
 
 import (
 	"net/http"
-
-	"github.com/lesismal/llib/std/crypto/tls"
 )
 
 // Server .
@@ -19,12 +17,5 @@ type Server struct {
 func NewServer(conf Config, handler http.Handler, messageHandlerExecutor func(f func()), v ...interface{}) *Server {
 	args := append([]interface{}{handler, messageHandlerExecutor}, v...)
 	engine := NewEngine(conf, args...)
-	return &Server{Engine: engine}
-}
-
-// NewServerTLS .
-func NewServerTLS(conf Config, handler http.Handler, messageHandlerExecutor func(f func()), tlsConfig *tls.Config, v ...interface{}) *Server {
-	args := append([]interface{}{handler, messageHandlerExecutor, tlsConfig}, v...)
-	engine := NewEngineTLS(conf, args...)
 	return &Server{Engine: engine}
 }

--- a/nbhttp/server.go
+++ b/nbhttp/server.go
@@ -6,6 +6,8 @@ package nbhttp
 
 import (
 	"net/http"
+
+	"github.com/lesismal/llib/std/crypto/tls"
 )
 
 // Server .
@@ -14,8 +16,46 @@ type Server struct {
 }
 
 // NewServer .
-func NewServer(conf Config, handler http.Handler, messageHandlerExecutor func(f func()), v ...interface{}) *Server {
-	args := append([]interface{}{handler, messageHandlerExecutor}, v...)
-	engine := NewEngine(conf, args...)
-	return &Server{Engine: engine}
+func NewServer(conf Config, v ...interface{}) *Server {
+	if conf.Handler != nil {
+		if len(v) > 0 {
+			if handler, ok := v[0].(http.Handler); ok {
+				conf.Handler = handler
+			}
+		}
+	}
+	if conf.ServerExecutor != nil {
+		if len(v) > 1 {
+			if messageHandlerExecutor, ok := v[1].(func(f func())); ok {
+				conf.ServerExecutor = messageHandlerExecutor
+			}
+		}
+	}
+	return &Server{Engine: NewEngine(conf)}
+}
+
+// NewServerTLS .
+func NewServerTLS(conf Config, v ...interface{}) *Server {
+	if conf.Handler != nil {
+		if len(v) > 0 {
+			if handler, ok := v[0].(http.Handler); ok {
+				conf.Handler = handler
+			}
+		}
+	}
+	if conf.ServerExecutor != nil {
+		if len(v) > 1 {
+			if messageHandlerExecutor, ok := v[1].(func(f func())); ok {
+				conf.ServerExecutor = messageHandlerExecutor
+			}
+		}
+	}
+	if conf.TLSConfig != nil {
+		if len(v) > 2 {
+			if tlsConfig, ok := v[2].(*tls.Config); ok {
+				conf.TLSConfig = tlsConfig
+			}
+		}
+	}
+	return &Server{Engine: NewEngine(conf)}
 }

--- a/nbhttp/tests/poller_test.go
+++ b/nbhttp/tests/poller_test.go
@@ -60,9 +60,11 @@ func server(ctx context.Context, started *sync.WaitGroup, startupError *error) {
 	mux.HandleFunc("/wss", onWebsocket)
 
 	svr = nbhttp.NewServer(nbhttp.Config{
-		Network:  "tcp",
-		AddrsTLS: []nbhttp.ConfTLSAddr{{Addrs: []string{":8889"}, TLSConfig: tlsConfig}},
-	}, mux, nil)
+		Network:   "tcp",
+		AddrsTLS:  []string{":8889"},
+		TLSConfig: tlsConfig,
+		Handler:   mux,
+	})
 
 	err = svr.Start()
 	if err != nil {

--- a/nbhttp/tests/poller_test.go
+++ b/nbhttp/tests/poller_test.go
@@ -59,10 +59,10 @@ func server(ctx context.Context, started *sync.WaitGroup, startupError *error) {
 	mux := &http.ServeMux{}
 	mux.HandleFunc("/wss", onWebsocket)
 
-	svr = nbhttp.NewServerTLS(nbhttp.Config{
-		Network: "tcp",
-		Addrs:   []string{":8889"},
-	}, mux, nil, tlsConfig)
+	svr = nbhttp.NewServer(nbhttp.Config{
+		Network:  "tcp",
+		AddrsTLS: []nbhttp.ConfTLSAddr{{Addrs: []string{":8889"}, TLSConfig: tlsConfig}},
+	}, mux, nil)
 
 	err = svr.Start()
 	if err != nil {


### PR DESCRIPTION
1. http engine: support both tls/non-tls together, support cleint by default
2. http: enable sendfile by default
