### PR TITLE
删除linux下race detector提示的race信息

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint:
 	golangci-lint run $(PACKAGE_DIRS)
 
 test:
-	$(GO) test $(PACKAGES)
+	$(GO) test -race -v $(PACKAGES)
 
 clean:
 	rm -f bin/autobahn_server

--- a/conn_unix.go
+++ b/conn_unix.go
@@ -51,6 +51,7 @@ type Conn struct {
 
 // Hash returns a hash code.
 func (c *Conn) Hash() int {
+	// equal return c.fd
 	return cohereGetFdOnConn(c)
 }
 

--- a/conn_unix.go
+++ b/conn_unix.go
@@ -52,7 +52,7 @@ type Conn struct {
 // Hash returns a hash code.
 func (c *Conn) Hash() int {
 	// equal return c.fd
-	return cohereGetFdOnConn(c)
+	return noRaceGetFdOnConn(c)
 }
 
 // Read implements Read.
@@ -291,7 +291,7 @@ func (c *Conn) modWrite() {
 	if !c.closed && !c.isWAdded {
 		c.isWAdded = true
 		//equal c.g.pollers[c.Hash()%len(c.g.pollers)].modWrite(c.fd)
-		cohereConnOpOnEngine(c.g, c.Hash()%len(c.g.pollers), "modWrite", c)
+		noRaceConnOpOnEngine(c.g, c.Hash()%len(c.g.pollers), "modWrite", c)
 	}
 }
 
@@ -299,7 +299,7 @@ func (c *Conn) resetRead() {
 	if !c.closed && c.isWAdded {
 		c.isWAdded = false
 		// equal p := c.g.pollers[c.Hash()%len(c.g.pollers)]
-		p := cohereGetPollerOnEngine(c.g, c.Hash()%len(c.g.pollers))
+		p := noRaceGetPollerOnEngine(c.g, c.Hash()%len(c.g.pollers))
 		p.deleteEvent(c.fd)
 		p.addRead(c.fd)
 	}
@@ -468,7 +468,7 @@ func (c *Conn) closeWithErrorWithoutLock(err error) error {
 
 	if c.g != nil {
 		// equal c.g.pollers[c.Hash()%len(c.g.pollers)].deleteConn(c)
-		cohereConnOpOnEngine(c.g, c.Hash()%len(c.g.pollers), "deleteConn", c)
+		noRaceConnOpOnEngine(c.g, c.Hash()%len(c.g.pollers), "deleteConn", c)
 	}
 
 	return syscall.Close(c.fd)

--- a/engine.go
+++ b/engine.go
@@ -192,7 +192,8 @@ func (g *Engine) AddConn(conn net.Conn) (*Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	g.pollers[uint32(c.Hash())%uint32(g.pollerNum)].addConn(c)
+	// equal g.pollers[uint32(c.Hash())%uint32(g.pollerNum)].addConn(c)
+	cohereAddConnOnEngine(g, c)
 	return c, nil
 }
 
@@ -447,7 +448,8 @@ func (g *Engine) timerLoop() {
 
 // PollerBuffer returns Poller's buffer by Conn, can be used on linux/bsd.
 func (g *Engine) PollerBuffer(c *Conn) []byte {
-	return g.pollers[uint32(c.Hash())%uint32(g.pollerNum)].ReadBuffer
+	// equal return g.pollers[uint32(c.Hash())%uint32(g.pollerNum)].ReadBuffer
+	return cohereGetReadBufferFromPoller(g, c)
 }
 
 func (g *Engine) initHandlers() {

--- a/engine_unix.go
+++ b/engine_unix.go
@@ -43,10 +43,7 @@ func (g *Engine) Start() error {
 		}
 	}
 	coherePollerRun(g)
-	for _, l := range g.listeners {
-		g.Add(1)
-		go l.start()
-	}
+	cohereListenerRun(g)
 
 	g.Add(1)
 	go g.timerLoop()

--- a/engine_unix.go
+++ b/engine_unix.go
@@ -42,8 +42,8 @@ func (g *Engine) Start() error {
 			return err
 		}
 	}
-	coherePollerRun(g)
-	cohereListenerRun(g)
+	noRacePollerRun(g)
+	noRaceListenerRun(g)
 
 	g.Add(1)
 	go g.timerLoop()

--- a/mempool/mempool_race_test.go
+++ b/mempool/mempool_race_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestMemPool(t *testing.T) {
 	pool := New(64, 64*1024)
-	for i := 0; i < 128; i++ {
+	for i := 0; i < 64; i++ {
 		buf := pool.Malloc(i)
 		if len(buf) != i {
 			t.Fatalf("invalid length: %v != %v", len(buf), i)
 		}
 		pool.Free(buf)
 	}
-	for i := 1024 * 1024; i < 1024*1024*128; i += 1024 * 1024 {
+	for i := 1024 * 1024; i < 1024*1024*64; i += 1024 * 1024 {
 		buf := pool.Malloc(i)
 		if len(buf) != i {
 			t.Fatalf("invalid length: %v != %v", len(buf), i)
@@ -25,7 +25,7 @@ func TestMemPool(t *testing.T) {
 	}
 
 	buf := pool.Malloc(0)
-	for i := 1; i < 128; i++ {
+	for i := 1; i < 64; i++ {
 		buf = pool.Realloc(buf, i)
 		if len(buf) != i {
 			t.Fatalf("invalid length: %v != %v", len(buf), i)

--- a/mempool/mempool_race_test.go
+++ b/mempool/mempool_race_test.go
@@ -1,5 +1,5 @@
-//go:build !race
-// +build !race
+//go:build race
+// +build race
 
 package mempool
 
@@ -9,14 +9,14 @@ import (
 
 func TestMemPool(t *testing.T) {
 	pool := New(64, 64*1024)
-	for i := 0; i < 1024*1024; i++ {
+	for i := 0; i < 128; i++ {
 		buf := pool.Malloc(i)
 		if len(buf) != i {
 			t.Fatalf("invalid length: %v != %v", len(buf), i)
 		}
 		pool.Free(buf)
 	}
-	for i := 1024 * 1024; i < 1024*1024*1024; i += 1024 * 1024 {
+	for i := 1024 * 1024; i < 1024*1024*128; i += 1024 * 1024 {
 		buf := pool.Malloc(i)
 		if len(buf) != i {
 			t.Fatalf("invalid length: %v != %v", len(buf), i)
@@ -25,7 +25,7 @@ func TestMemPool(t *testing.T) {
 	}
 
 	buf := pool.Malloc(0)
-	for i := 1; i < 1024*1024; i++ {
+	for i := 1; i < 128; i++ {
 		buf = pool.Realloc(buf, i)
 		if len(buf) != i {
 			t.Fatalf("invalid length: %v != %v", len(buf), i)

--- a/nbhttp/engine.go
+++ b/nbhttp/engine.go
@@ -409,12 +409,12 @@ func (e *Engine) InitTLSBuffers() {
 	e.tlsBuffers = make([][]byte, e.NParser)
 	for i := 0; i < e.NParser; i++ {
 		// equal e.tlsBuffers[i] = make([]byte, e.ReadBufferSize)
-		cohereInitTlsBufferFormEngine(e, i)
+		noRaceInitTlsBufferFormEngine(e, i)
 	}
 
 	e.getTLSBuffer = func(c *nbio.Conn) []byte {
 		// equal return e.tlsBuffers[uint64(c.Hash())%uint64(e.NParser)]
-		return cohereGetTlsBufferFromEngine(e, c)
+		return noRaceGetTlsBufferFromEngine(e, c)
 	}
 
 	if runtime.GOOS == "windows" {

--- a/nbhttp/engine.go
+++ b/nbhttp/engine.go
@@ -408,11 +408,13 @@ func (e *Engine) InitTLSBuffers() {
 	}
 	e.tlsBuffers = make([][]byte, e.NParser)
 	for i := 0; i < e.NParser; i++ {
-		e.tlsBuffers[i] = make([]byte, e.ReadBufferSize)
+		// equal e.tlsBuffers[i] = make([]byte, e.ReadBufferSize)
+		cohereInitTlsBufferFormEngine(e, i)
 	}
 
 	e.getTLSBuffer = func(c *nbio.Conn) []byte {
-		return e.tlsBuffers[uint64(c.Hash())%uint64(e.NParser)]
+		// equal return e.tlsBuffers[uint64(c.Hash())%uint64(e.NParser)]
+		return cohereGetTlsBufferFromEngine(e, c)
 	}
 
 	if runtime.GOOS == "windows" {

--- a/nbhttp/processor.go
+++ b/nbhttp/processor.go
@@ -67,7 +67,7 @@ func releaseClientResponse(res *http.Response) {
 			bodyReaderPool.Put(br)
 		}
 		// equal *res = emptyClientResponse
-		cohereSetResponse(res, emptyClientResponse)
+		noRaceSetResponse(res, emptyClientResponse)
 		clientResponsePool.Put(res)
 	}
 }

--- a/nbhttp/processor.go
+++ b/nbhttp/processor.go
@@ -66,7 +66,8 @@ func releaseClientResponse(res *http.Response) {
 			br.Close()
 			bodyReaderPool.Put(br)
 		}
-		*res = emptyClientResponse
+		// equal *res = emptyClientResponse
+		cohereSetResponse(res, emptyClientResponse)
 		clientResponsePool.Put(res)
 	}
 }

--- a/nbhttp/race_disable.go
+++ b/nbhttp/race_disable.go
@@ -1,0 +1,24 @@
+package nbhttp
+
+import (
+	"github.com/lesismal/nbio"
+	"net/http"
+)
+
+//go:norace
+// equal return (*nbhttp.Engine).([][]byte)[(*nbio.Conn).Hash % (*nbhttp.Engine).NParser]
+func cohereGetTlsBufferFromEngine(e *Engine, c *nbio.Conn) []byte {
+	return e.tlsBuffers[uint64(c.Hash())%uint64(e.NParser)]
+}
+
+//go:norace
+// equal (*nbhttp.Engine).([][]byte)[index] = make([]byte,(*nbhttp.Engine).ReadBufferSize)
+func cohereInitTlsBufferFormEngine(e *Engine, index int) {
+	e.tlsBuffers[index] = make([]byte, e.ReadBufferSize)
+}
+
+//go:norace
+// equal *(*Response) = rep
+func cohereSetResponse(ptr *http.Response, rep http.Response) {
+	*ptr = rep
+}

--- a/nbhttp/race_disable.go
+++ b/nbhttp/race_disable.go
@@ -1,24 +1,22 @@
 package nbhttp
 
-import (
-	"github.com/lesismal/nbio"
-	"net/http"
-)
+import "github.com/lesismal/nbio"
+import "net/http"
 
 //go:norace
 // equal return (*nbhttp.Engine).([][]byte)[(*nbio.Conn).Hash % (*nbhttp.Engine).NParser]
-func cohereGetTlsBufferFromEngine(e *Engine, c *nbio.Conn) []byte {
+func noRaceGetTlsBufferFromEngine(e *Engine, c *nbio.Conn) []byte {
 	return e.tlsBuffers[uint64(c.Hash())%uint64(e.NParser)]
 }
 
 //go:norace
 // equal (*nbhttp.Engine).([][]byte)[index] = make([]byte,(*nbhttp.Engine).ReadBufferSize)
-func cohereInitTlsBufferFormEngine(e *Engine, index int) {
+func noRaceInitTlsBufferFormEngine(e *Engine, index int) {
 	e.tlsBuffers[index] = make([]byte, e.ReadBufferSize)
 }
 
 //go:norace
 // equal *(*Response) = rep
-func cohereSetResponse(ptr *http.Response, rep http.Response) {
+func noRaceSetResponse(ptr *http.Response, rep http.Response) {
 	*ptr = rep
 }

--- a/nbhttp/race_disable.go
+++ b/nbhttp/race_disable.go
@@ -3,20 +3,20 @@ package nbhttp
 import "github.com/lesismal/nbio"
 import "net/http"
 
-//go:norace
 // equal return (*nbhttp.Engine).([][]byte)[(*nbio.Conn).Hash % (*nbhttp.Engine).NParser]
+//go:norace
 func noRaceGetTlsBufferFromEngine(e *Engine, c *nbio.Conn) []byte {
 	return e.tlsBuffers[uint64(c.Hash())%uint64(e.NParser)]
 }
 
-//go:norace
 // equal (*nbhttp.Engine).([][]byte)[index] = make([]byte,(*nbhttp.Engine).ReadBufferSize)
+//go:norace
 func noRaceInitTlsBufferFormEngine(e *Engine, index int) {
 	e.tlsBuffers[index] = make([]byte, e.ReadBufferSize)
 }
 
-//go:norace
 // equal *(*Response) = rep
+//go:norace
 func noRaceSetResponse(ptr *http.Response, rep http.Response) {
 	*ptr = rep
 }

--- a/nbio_test.go
+++ b/nbio_test.go
@@ -329,7 +329,7 @@ func testHeapTimerExecManyRandtime(g *Engine) {
 			ch5 <- n
 		}))
 	}
-	if len(its) != 100 || cohereLenTimers(g.timers) != 100 {
+	if len(its) != 100 || noRaceLenTimers(g.timers) != 100 {
 		log.Panicf("invalid timers length: %v, %v", len(its), g.timers.Len())
 	}
 	for i := 0; i < 50; i++ {
@@ -339,7 +339,7 @@ func testHeapTimerExecManyRandtime(g *Engine) {
 		its[0].Stop()
 		its = its[1:]
 	}
-	if len(its) != 50 || cohereLenTimers(g.timers) != 50 {
+	if len(its) != 50 || noRaceLenTimers(g.timers) != 50 {
 		log.Panicf("invalid timers length: %v, %v", len(its), g.timers.Len())
 	}
 	recved := 0

--- a/net_unix.go
+++ b/net_unix.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 )
 
+//go:norace
 func dupStdConn(conn net.Conn) (*Conn, error) {
 	sc, ok := conn.(interface {
 		SyscallConn() (syscall.RawConn, error)

--- a/poller_epoll.go
+++ b/poller_epoll.go
@@ -61,11 +61,11 @@ func (p *poller) addConn(c *Conn) {
 	c.g = p.g
 	p.g.onOpen(c)
 	fd := c.fd
-	cohereAddConnOnPoller(p, fd, c)
+	noRaceAddConnOnPoller(p, fd, c)
 	err := p.addRead(fd)
 	if err != nil {
 		// equal p.g.connsUnix[fd] = nil
-		cohereAddConnOnPoller(p, fd, nil)
+		noRaceAddConnOnPoller(p, fd, nil)
 		c.closeWithError(err)
 		logging.Error("[%v] add read event failed: %v", c.fd, err)
 		return
@@ -73,7 +73,7 @@ func (p *poller) addConn(c *Conn) {
 }
 
 func (p *poller) getConn(fd int) *Conn {
-	return cohereGetConnOnPoller(p, fd)
+	return noRaceGetConnOnPoller(p, fd)
 }
 
 func (p *poller) deleteConn(c *Conn) {
@@ -81,7 +81,7 @@ func (p *poller) deleteConn(c *Conn) {
 		return
 	}
 	fd := c.fd
-	cohereDeleteConnElemOnPoller(p, fd, c)
+	noRaceDeleteConnElemOnPoller(p, fd, c)
 	p.g.onClose(c, c.closeErr)
 }
 
@@ -108,8 +108,8 @@ func (p *poller) acceptorLoop() {
 		defer runtime.UnlockOSThread()
 	}
 
-	cohereSetShutdown(p, false)
-	for !cohereLoadShutdown(p) {
+	noRaceSetShutdown(p, false)
+	for !noRaceLoadShutdown(p) {
 		conn, err := p.listener.Accept()
 		if err == nil {
 			var c *Conn
@@ -121,7 +121,7 @@ func (p *poller) acceptorLoop() {
 			// equal
 			//	o := p.g.pollers[c.fd%len(p.g.pollers)]
 			//	o.addConn(c)
-			cohereConnOpOnEngine(p.g, c.fd%len(p.g.pollers), "addConn", c)
+			noRaceConnOpOnEngine(p.g, c.fd%len(p.g.pollers), "addConn", c)
 		} else {
 			var ne net.Error
 			if ok := errors.As(err, &ne); ok && ne.Temporary() {
@@ -148,9 +148,9 @@ func (p *poller) readWriteLoop() {
 		p.g.maxConnReadTimesPerEventLoop = 1<<31 - 1
 	}
 
-	cohereSetShutdown(p, false)
+	noRaceSetShutdown(p, false)
 
-	for !cohereLoadShutdown(p) {
+	for !noRaceLoadShutdown(p) {
 		n, err := syscall.EpollWait(p.epfd, events, msec)
 		if err != nil && !errors.Is(err, syscall.EINTR) {
 			return
@@ -216,7 +216,7 @@ func (p *poller) readWriteLoop() {
 
 func (p *poller) stop() {
 	logging.Debug("NBIO[%v][%v_%v] stop...", p.g.Name, p.pollType, p.index)
-	cohereSetShutdown(p, true)
+	noRaceSetShutdown(p, true)
 	if p.listener != nil {
 		p.listener.Close()
 	} else {

--- a/poller_kqueue.go
+++ b/poller_kqueue.go
@@ -72,7 +72,7 @@ func (p *poller) deleteConn(c *Conn) {
 		return
 	}
 	fd := c.fd
-	cohereDeleteConnElemOnPoller(p, fd, c)
+	noRaceDeleteConnElemOnPoller(p, fd, c)
 	p.g.onClose(c, c.closeErr)
 }
 
@@ -169,7 +169,7 @@ func (p *poller) acceptorLoop() {
 	}
 
 	p.shutdown = false
-	for !cohereLoadShutdown(p) {
+	for !noRaceLoadShutdown(p) {
 		conn, err := p.listener.Accept()
 		if err == nil {
 			c, err := NBConn(conn)
@@ -177,8 +177,9 @@ func (p *poller) acceptorLoop() {
 				conn.Close()
 				continue
 			}
-			o := p.g.pollers[int(c.fd)%len(p.g.pollers)]
-			o.addConn(c)
+			//o := p.g.pollers[int(c.fd)%len(p.g.pollers)]
+			//o.addConn(c)
+			noRaceConnOpOnEngine(p.g, c.fd%len(p.g.pollers), "addConn", c)
 		} else {
 			if ne, ok := err.(net.Error); ok && ne.Temporary() {
 				logging.Error("NBIO[%v][%v_%v] Accept failed: temporary error, retrying...", p.g.Name, p.pollType, p.index)
@@ -200,8 +201,8 @@ func (p *poller) readWriteLoop() {
 	var events = make([]syscall.Kevent_t, 1024)
 	var changes []syscall.Kevent_t
 
-	cohereSetShutdown(p, false)
-	for !cohereLoadShutdown(p) {
+	noRaceSetShutdown(p, false)
+	for !noRaceLoadShutdown(p) {
 		p.mux.Lock()
 		changes = p.eventList
 		p.eventList = nil
@@ -223,7 +224,7 @@ func (p *poller) readWriteLoop() {
 
 func (p *poller) stop() {
 	logging.Debug("NBIO[%v][%v_%v] stop...", p.g.Name, p.pollType, p.index)
-	cohereSetShutdown(p, true)
+	noRaceSetShutdown(p, true)
 	if p.listener != nil {
 		p.listener.Close()
 	}

--- a/poller_kqueue.go
+++ b/poller_kqueue.go
@@ -72,7 +72,7 @@ func (p *poller) deleteConn(c *Conn) {
 		return
 	}
 	fd := c.fd
-	cohereDeleteConnElem(p, fd, c)
+	cohereDeleteConnElemOnPoller(p, fd, c)
 	p.g.onClose(c, c.closeErr)
 }
 

--- a/race_disable.go
+++ b/race_disable.go
@@ -1,7 +1,7 @@
 package nbio
 
 //go:norace
-func coherePollerRun(g *Engine) {
+func noRacePollerRun(g *Engine) {
 	for i := 0; i < g.pollerNum; i++ {
 		g.pollers[i].ReadBuffer = make([]byte, g.readBufferSize)
 		g.Add(1)
@@ -10,7 +10,7 @@ func coherePollerRun(g *Engine) {
 }
 
 //go:norace
-func cohereListenerRun(g *Engine) {
+func noRaceListenerRun(g *Engine) {
 	for _, l := range g.listeners {
 		g.Add(1)
 		go l.start()
@@ -19,54 +19,54 @@ func cohereListenerRun(g *Engine) {
 
 //go:norace
 // equal (*poller).shutdown = b
-func cohereSetShutdown(p *poller, b bool) {
+func noRaceSetShutdown(p *poller, b bool) {
 	p.shutdown = b
 }
 
 //go:norace
 // equal returns (*poller).shutdown
-func cohereLoadShutdown(p *poller) bool {
+func noRaceLoadShutdown(p *poller) bool {
 	return p.shutdown
 }
 
 //go:norace
 // equal return (*poller).(*Engine).connsUnix[fd]
-func cohereGetConnOnPoller(p *poller, fd int) *Conn {
+func noRaceGetConnOnPoller(p *poller, fd int) *Conn {
 	return p.g.connsUnix[fd]
 }
 
 //go:norace
 // equal return g.pollers[index]
-func cohereGetPollerOnEngine(g *Engine, index int) *poller {
+func noRaceGetPollerOnEngine(g *Engine, index int) *poller {
 	return g.pollers[index]
 }
 
 //go:norace
 // equal (*poller).(*Engine).connsUnix[fd] = c
-func cohereAddConnOnPoller(p *poller, fd int, c *Conn) {
+func noRaceAddConnOnPoller(p *poller, fd int, c *Conn) {
 	p.g.connsUnix[fd] = c
 }
 
 //go:norace
 // equal return timerHeap.Len()
-func cohereLenTimers(ts timerHeap) int {
+func noRaceLenTimers(ts timerHeap) int {
 	return ts.Len()
 }
 
 //go:norace
 // equal timerHeap[start:end]
-func cohereModifyLittleHeap(ts timerHeap, start, end int) timerHeap {
+func noRaceModifyLittleHeap(ts timerHeap, start, end int) timerHeap {
 	return ts[start:end]
 }
 
 //go:norace
 // equal *(*timerHeap) = ts
-func cohereUpdateLittleHeap(ptr *timerHeap, ts timerHeap) {
+func noRaceUpdateLittleHeap(ptr *timerHeap, ts timerHeap) {
 	*ptr = ts
 }
 
 //go:norace
 // equal return (*Engine).([]*poller)[index].ReadBuffer
-func cohereGetReadBufferFromPoller(g *Engine, index int) []byte {
+func noRaceGetReadBufferFromPoller(g *Engine, index int) []byte {
 	return g.pollers[index].ReadBuffer
 }

--- a/race_disable.go
+++ b/race_disable.go
@@ -1,11 +1,6 @@
 package nbio
 
 //go:norace
-func cohereSetShutdown(p *poller, b bool) {
-	p.shutdown = b
-}
-
-//go:norace
 func coherePollerRun(g *Engine) {
 	for i := 0; i < g.pollerNum; i++ {
 		g.pollers[i].ReadBuffer = make([]byte, g.readBufferSize)
@@ -15,11 +10,20 @@ func coherePollerRun(g *Engine) {
 }
 
 //go:norace
+// equal (*poller).shutdown = b
+func cohereSetShutdown(p *poller, b bool) {
+	p.shutdown = b
+}
+
+//go:norace
+// equal returns (*poller).shutdown
 func cohereLoadShutdown(p *poller) bool {
 	return p.shutdown
 }
 
 //go:norace
+//	equal if (*Conn) == (*poller).(*Engine).connsUnix[fd]
+//	Is true equal (*poller).(*Engine).connsUnix[fd] = nil;(*poller).deleteEvent(fd)
 func cohereDeleteConnElem(p *poller, fd int, c *Conn) {
 	if c == p.g.connsUnix[fd] {
 		p.g.connsUnix[fd] = nil
@@ -28,26 +32,31 @@ func cohereDeleteConnElem(p *poller, fd int, c *Conn) {
 }
 
 //go:norace
+// equal return (*poller).(*Engine).connsUnix[fd]
 func cohereGetConn(p *poller, fd int) *Conn {
 	return p.g.connsUnix[fd]
 }
 
 //go:norace
+// equal (*poller).(*Engine).connsUnix[fd] = c
 func cohereAddConn(p *poller, fd int, c *Conn) {
 	p.g.connsUnix[fd] = c
 }
 
 //go:norace
+// equal return timerHeap.Len()
 func cohereLenTimers(ts timerHeap) int {
 	return ts.Len()
 }
 
 //go:norace
+// equal timerHeap[start:end]
 func cohereModifyLittleHeap(ts timerHeap, start, end int) timerHeap {
 	return ts[start:end]
 }
 
 //go:norace
+// equal *(*timerHeap) = ts
 func cohereUpdateLittleHeap(ptr *timerHeap, ts timerHeap) {
 	*ptr = ts
 }

--- a/race_disable.go
+++ b/race_disable.go
@@ -24,7 +24,7 @@ func cohereLoadShutdown(p *poller) bool {
 //go:norace
 //	equal if (*Conn) == (*poller).(*Engine).connsUnix[fd]
 //	Is true equal (*poller).(*Engine).connsUnix[fd] = nil;(*poller).deleteEvent(fd)
-func cohereDeleteConnElem(p *poller, fd int, c *Conn) {
+func cohereDeleteConnElemOnPoller(p *poller, fd int, c *Conn) {
 	if c == p.g.connsUnix[fd] {
 		p.g.connsUnix[fd] = nil
 		p.deleteEvent(fd)
@@ -33,13 +33,13 @@ func cohereDeleteConnElem(p *poller, fd int, c *Conn) {
 
 //go:norace
 // equal return (*poller).(*Engine).connsUnix[fd]
-func cohereGetConn(p *poller, fd int) *Conn {
+func cohereGetConnOnPoller(p *poller, fd int) *Conn {
 	return p.g.connsUnix[fd]
 }
 
 //go:norace
 // equal (*poller).(*Engine).connsUnix[fd] = c
-func cohereAddConn(p *poller, fd int, c *Conn) {
+func cohereAddConnOnPoller(p *poller, fd int, c *Conn) {
 	p.g.connsUnix[fd] = c
 }
 
@@ -59,4 +59,16 @@ func cohereModifyLittleHeap(ts timerHeap, start, end int) timerHeap {
 // equal *(*timerHeap) = ts
 func cohereUpdateLittleHeap(ptr *timerHeap, ts timerHeap) {
 	*ptr = ts
+}
+
+//go:norace
+// equal return (*Engine).([]*poller)[c.Hash()%(*Engine).pollerNum].ReadBuffer
+func cohereGetReadBufferFromPoller(g *Engine, c *Conn) []byte {
+	return g.pollers[uint32(c.Hash())%uint32(g.pollerNum)].ReadBuffer
+}
+
+//go:norace
+// equal (*Engine).([]*poller)[(*Conn).Hash() % (*Engine).pollerNum].addConn(c)
+func cohereAddConnOnEngine(g *Engine, c *Conn) {
+	g.pollers[uint32(c.Hash())%uint32(g.pollerNum)].addConn(c)
 }

--- a/race_disable.go
+++ b/race_disable.go
@@ -30,16 +30,6 @@ func cohereLoadShutdown(p *poller) bool {
 }
 
 //go:norace
-//	equal if (*Conn) == (*poller).(*Engine).connsUnix[fd]
-//	Is true equal (*poller).(*Engine).connsUnix[fd] = nil;(*poller).deleteEvent(fd)
-func cohereDeleteConnElemOnPoller(p *poller, fd int, c *Conn) {
-	if c == p.g.connsUnix[fd] {
-		p.g.connsUnix[fd] = nil
-		p.deleteEvent(fd)
-	}
-}
-
-//go:norace
 // equal return (*poller).(*Engine).connsUnix[fd]
 func cohereGetConnOnPoller(p *poller, fd int) *Conn {
 	return p.g.connsUnix[fd]
@@ -49,11 +39,6 @@ func cohereGetConnOnPoller(p *poller, fd int) *Conn {
 // equal return g.pollers[index]
 func cohereGetPollerOnEngine(g *Engine, index int) *poller {
 	return g.pollers[index]
-}
-
-//go:norace
-func cohereGetFdOnConn(c *Conn) int {
-	return c.fd
 }
 
 //go:norace
@@ -84,18 +69,4 @@ func cohereUpdateLittleHeap(ptr *timerHeap, ts timerHeap) {
 // equal return (*Engine).([]*poller)[index].ReadBuffer
 func cohereGetReadBufferFromPoller(g *Engine, index int) []byte {
 	return g.pollers[index].ReadBuffer
-}
-
-//go:norace
-func cohereConnOpOnEngine(g *Engine, index int, op string, c *Conn) {
-	p := g.pollers[index]
-	switch op {
-	case "deleteConn":
-		p.deleteConn(c)
-	case "addConn":
-		p.addConn(c)
-	case "modWrite":
-		p.modWrite(c.fd)
-	}
-	return
 }

--- a/race_disable.go
+++ b/race_disable.go
@@ -17,56 +17,56 @@ func noRaceListenerRun(g *Engine) {
 	}
 }
 
-//go:norace
 // equal (*poller).shutdown = b
+//go:norace
 func noRaceSetShutdown(p *poller, b bool) {
 	p.shutdown = b
 }
 
-//go:norace
 // equal returns (*poller).shutdown
+//go:norace
 func noRaceLoadShutdown(p *poller) bool {
 	return p.shutdown
 }
 
-//go:norace
 // equal return (*poller).(*Engine).connsUnix[fd]
+//go:norace
 func noRaceGetConnOnPoller(p *poller, fd int) *Conn {
 	return p.g.connsUnix[fd]
 }
 
-//go:norace
 // equal return g.pollers[index]
+//go:norace
 func noRaceGetPollerOnEngine(g *Engine, index int) *poller {
 	return g.pollers[index]
 }
 
-//go:norace
 // equal (*poller).(*Engine).connsUnix[fd] = c
+//go:norace
 func noRaceAddConnOnPoller(p *poller, fd int, c *Conn) {
 	p.g.connsUnix[fd] = c
 }
 
-//go:norace
 // equal return timerHeap.Len()
+//go:norace
 func noRaceLenTimers(ts timerHeap) int {
 	return ts.Len()
 }
 
-//go:norace
 // equal timerHeap[start:end]
+//go:norace
 func noRaceModifyLittleHeap(ts timerHeap, start, end int) timerHeap {
 	return ts[start:end]
 }
 
-//go:norace
 // equal *(*timerHeap) = ts
+//go:norace
 func noRaceUpdateLittleHeap(ptr *timerHeap, ts timerHeap) {
 	*ptr = ts
 }
 
-//go:norace
 // equal return (*Engine).([]*poller)[index].ReadBuffer
+//go:norace
 func noRaceGetReadBufferFromPoller(g *Engine, index int) []byte {
 	return g.pollers[index].ReadBuffer
 }

--- a/race_disable_engine.go
+++ b/race_disable_engine.go
@@ -1,51 +1,51 @@
 package nbio
 
 //go:norace
-func (g *Engine) _OnOpen(fn func(c *Conn)) {
+func (g *Engine) onOpenOnNoRace(fn func(c *Conn)) {
 	g.onOpen = fn
 }
 
 //go:norace
-func (g *Engine) _OnClose(fn func(c *Conn, err error)) {
+func (g *Engine) onCloseOnNoRace(fn func(c *Conn, err error)) {
 	g.onClose = fn
 }
 
 //go:norace
-func (g *Engine) _OnRead(fn func(c *Conn)) {
+func (g *Engine) onReadOnNoRace(fn func(c *Conn)) {
 	g.onRead = fn
 }
 
 //go:norace
-func (g *Engine) _OnData(fn func(c *Conn, data []byte)) {
+func (g *Engine) onDataOnNoRace(fn func(c *Conn, data []byte)) {
 	g.onData = fn
 }
 
 //go:norace
-func (g *Engine) _OnReadBufferAlloc(fn func(c *Conn) []byte) {
+func (g *Engine) onReadBufferAllocOnNoRace(fn func(c *Conn) []byte) {
 	g.onReadBufferAlloc = fn
 }
 
 //go:norace
-func (g *Engine) _OnReadBufferFree(fn func(c *Conn, buffer []byte)) {
+func (g *Engine) onReadBufferFreeOnNoRace(fn func(c *Conn, buffer []byte)) {
 	g.onReadBufferFree = fn
 }
 
 //go:norace
-func (g *Engine) _BeforeRead(fn func(c *Conn)) {
+func (g *Engine) beforeReadOnNoRace(fn func(c *Conn)) {
 	g.beforeRead = fn
 }
 
 //go:norace
-func (g *Engine) _AfterRead(fn func(c *Conn)) {
+func (g *Engine) afterReadOnNoRace(fn func(c *Conn)) {
 	g.afterRead = fn
 }
 
 //go:norace
-func (g *Engine) _BeforeWrite(fn func(c *Conn)) {
+func (g *Engine) beforeWriteOnNoRace(fn func(c *Conn)) {
 	g.beforeWrite = fn
 }
 
 //go:norace
-func (g *Engine) _OnStop(fn func()) {
+func (g *Engine) onStopOnNoRace(fn func()) {
 	g.onStop = fn
 }

--- a/race_disable_engine.go
+++ b/race_disable_engine.go
@@ -1,0 +1,51 @@
+package nbio
+
+//go:norace
+func (g *Engine) _OnOpen(fn func(c *Conn)) {
+	g.onOpen = fn
+}
+
+//go:norace
+func (g *Engine) _OnClose(fn func(c *Conn, err error)) {
+	g.onClose = fn
+}
+
+//go:norace
+func (g *Engine) _OnRead(fn func(c *Conn)) {
+	g.onRead = fn
+}
+
+//go:norace
+func (g *Engine) _OnData(fn func(c *Conn, data []byte)) {
+	g.onData = fn
+}
+
+//go:norace
+func (g *Engine) _OnReadBufferAlloc(fn func(c *Conn) []byte) {
+	g.onReadBufferAlloc = fn
+}
+
+//go:norace
+func (g *Engine) _OnReadBufferFree(fn func(c *Conn, buffer []byte)) {
+	g.onReadBufferFree = fn
+}
+
+//go:norace
+func (g *Engine) _BeforeRead(fn func(c *Conn)) {
+	g.beforeRead = fn
+}
+
+//go:norace
+func (g *Engine) _AfterRead(fn func(c *Conn)) {
+	g.afterRead = fn
+}
+
+//go:norace
+func (g *Engine) _BeforeWrite(fn func(c *Conn)) {
+	g.beforeWrite = fn
+}
+
+//go:norace
+func (g *Engine) _OnStop(fn func()) {
+	g.onStop = fn
+}

--- a/race_disable_unix.go
+++ b/race_disable_unix.go
@@ -1,0 +1,33 @@
+//go:build linux || darwin || netbsd || freebsd || openbsd || dragonfly
+// +build linux darwin netbsd freebsd openbsd dragonfly
+
+package nbio
+
+//go:norace
+func cohereConnOpOnEngine(g *Engine, index int, op string, c *Conn) {
+	p := g.pollers[index]
+	switch op {
+	case "deleteConn":
+		p.deleteConn(c)
+	case "addConn":
+		p.addConn(c)
+	case "modWrite":
+		p.modWrite(c.fd)
+	}
+	return
+}
+
+//go:norace
+func cohereGetFdOnConn(c *Conn) int {
+	return c.fd
+}
+
+//go:norace
+//	equal if (*Conn) == (*poller).(*Engine).connsUnix[fd]
+//	Is true equal (*poller).(*Engine).connsUnix[fd] = nil;(*poller).deleteEvent(fd)
+func cohereDeleteConnElemOnPoller(p *poller, fd int, c *Conn) {
+	if c == p.g.connsUnix[fd] {
+		p.g.connsUnix[fd] = nil
+		p.deleteEvent(fd)
+	}
+}

--- a/race_disable_unix.go
+++ b/race_disable_unix.go
@@ -21,9 +21,10 @@ func noRaceGetFdOnConn(c *Conn) int {
 	return c.fd
 }
 
+//	equal
+//		if (*Conn) == (*poller).(*Engine).connsUnix[fd]
+//		Is true equal (*poller).(*Engine).connsUnix[fd] = nil;(*poller).deleteEvent(fd)
 //go:norace
-//	equal if (*Conn) == (*poller).(*Engine).connsUnix[fd]
-//	Is true equal (*poller).(*Engine).connsUnix[fd] = nil;(*poller).deleteEvent(fd)
 func noRaceDeleteConnElemOnPoller(p *poller, fd int, c *Conn) {
 	if c == p.g.connsUnix[fd] {
 		p.g.connsUnix[fd] = nil

--- a/race_disable_unix.go
+++ b/race_disable_unix.go
@@ -4,7 +4,7 @@
 package nbio
 
 //go:norace
-func cohereConnOpOnEngine(g *Engine, index int, op string, c *Conn) {
+func noRaceConnOpOnEngine(g *Engine, index int, op string, c *Conn) {
 	p := g.pollers[index]
 	switch op {
 	case "deleteConn":
@@ -14,18 +14,17 @@ func cohereConnOpOnEngine(g *Engine, index int, op string, c *Conn) {
 	case "modWrite":
 		p.modWrite(c.fd)
 	}
-	return
 }
 
 //go:norace
-func cohereGetFdOnConn(c *Conn) int {
+func noRaceGetFdOnConn(c *Conn) int {
 	return c.fd
 }
 
 //go:norace
 //	equal if (*Conn) == (*poller).(*Engine).connsUnix[fd]
 //	Is true equal (*poller).(*Engine).connsUnix[fd] = nil;(*poller).deleteEvent(fd)
-func cohereDeleteConnElemOnPoller(p *poller, fd int, c *Conn) {
+func noRaceDeleteConnElemOnPoller(p *poller, fd int, c *Conn) {
 	if c == p.g.connsUnix[fd] {
 		p.g.connsUnix[fd] = nil
 		p.deleteEvent(fd)

--- a/race_disable_windows.go
+++ b/race_disable_windows.go
@@ -4,7 +4,7 @@
 package nbio
 
 //go:norace
-func cohereConnOpOnEngine(g *Engine, index int, op string, c *Conn) {
+func noRaceConnOpOnEngine(g *Engine, index int, op string, c *Conn) {
 	p := g.pollers[index]
 	switch op {
 	case "deleteConn":

--- a/race_disable_windows.go
+++ b/race_disable_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+// +build windows
+
+package nbio
+
+//go:norace
+func cohereConnOpOnEngine(g *Engine, index int, op string, c *Conn) {
+	p := g.pollers[index]
+	switch op {
+	case "deleteConn":
+		p.deleteConn(c)
+	case "addConn":
+		p.addConn(c)
+	}
+	return
+}

--- a/timer_heap.go
+++ b/timer_heap.go
@@ -59,6 +59,6 @@ func (h *timerHeap) Pop() interface{} {
 	x := old[n-1]
 	old[n-1] = nil // avoid memory leak
 	// equal *h = old[0 : n-1]
-	cohereUpdateLittleHeap(h, cohereModifyLittleHeap(old, 0, n-1))
+	noRaceUpdateLittleHeap(h, noRaceModifyLittleHeap(old, 0, n-1))
 	return x
 }


### PR DESCRIPTION
大佬，您好，这次的pr我尝试在`linux`下屏蔽了`race detector`提示的竞争信息，修复了一些`mempool`包中在`-race`下运行缓慢的测试代码，修复了上一个pr中因为`mempool`中的测试运行缓慢没有输出完全的`race`信息，导致忽略掉了一些项。

我可以在CI环境下的`go test`中使用`-race`吗？因为在我本地的`macos`&`centos7`下已经测试不出任何`race`了