### PR TITLE
Expose the websocket subprotocol

### DIFF
--- a/nbhttp/websocket/conn.go
+++ b/nbhttp/websocket/conn.go
@@ -300,6 +300,11 @@ func (c *Conn) SetCompressionLevel(level int) error {
 	return nil
 }
 
+// The negotiated websocket subprotocol
+func (c *Conn) Subprotocol() string {
+	return c.subprotocol
+}
+
 func newConn(u *Upgrader, c net.Conn, subprotocol string, remoteCompressionEnabled bool) *Conn {
 	conn := &Conn{
 		Conn:                     c,


### PR DESCRIPTION
nbio currently does not expose the negotiated websocket subprotocol. This PR enables that.

The most common use for that is when someone is looking to implement a subprotocol of websocket like WAMP-proto. In that case the websocket server code needs to know what protocol was negotiated hence the relevant serializer object is initiated.

Here is an example of how exposing that value is useful https://github.com/gammazero/nexus/blob/v3/router/websocketserver.go#L355 -- that project uses gorilla but it does show why we need to expose Subprotocol value