### PR TITLE
fix epoll_add before epoll_mod && operate connsUnix []*Conn with RWMutex

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -105,7 +105,7 @@ type Engine struct {
 	Execute      func(f func())
 	TimerExecute func(f func())
 
-	mux sync.Mutex
+	mux sync.RWMutex
 
 	wgConn sync.WaitGroup
 

--- a/poller_epoll.go
+++ b/poller_epoll.go
@@ -69,16 +69,16 @@ func (p *poller) addConn(c *Conn) {
 		c.closeWithError(fmt.Errorf("too many open files, fd[%d] >= MaxOpenFiles[%d]", fd, len(p.g.connsUnix)))
 		return
 	}
-	c.p = p
-	if c.typ != ConnTypeUDPServer {
-		p.g.onOpen(c)
-	}
 	p.g.connsUnix[fd] = c
 	err := p.addRead(fd)
 	if err != nil {
 		p.g.connsUnix[fd] = nil
 		c.closeWithError(err)
 		logging.Error("[%v] add read event failed: %v", c.fd, err)
+	}
+	c.p = p
+	if c.typ != ConnTypeUDPServer {
+		p.g.onOpen(c)
 	}
 }
 

--- a/poller_epoll.go
+++ b/poller_epoll.go
@@ -69,10 +69,14 @@ func (p *poller) addConn(c *Conn) {
 		c.closeWithError(fmt.Errorf("too many open files, fd[%d] >= MaxOpenFiles[%d]", fd, len(p.g.connsUnix)))
 		return
 	}
+	p.g.mux.Lock()
 	p.g.connsUnix[fd] = c
+	p.g.mux.Unlock()
 	err := p.addRead(fd)
 	if err != nil {
+		p.g.mux.Lock()
 		p.g.connsUnix[fd] = nil
+		p.g.mux.Unlock()
 		c.closeWithError(err)
 		logging.Error("[%v] add read event failed: %v", c.fd, err)
 	}
@@ -83,6 +87,8 @@ func (p *poller) addConn(c *Conn) {
 }
 
 func (p *poller) getConn(fd int) *Conn {
+	p.g.mux.RLock()
+	defer p.g.mux.RUnlock()
 	return p.g.connsUnix[fd]
 }
 
@@ -94,7 +100,9 @@ func (p *poller) deleteConn(c *Conn) {
 
 	if c.typ != ConnTypeUDPClientFromRead {
 		if c == p.g.connsUnix[fd] {
+			p.g.mux.Lock()
 			p.g.connsUnix[fd] = nil
+			p.g.mux.Unlock()
 		}
 		p.deleteEvent(fd)
 	}


### PR DESCRIPTION
It's two issues were found with tests from https://github.com/lesismal/nbio-examples/blob/master/echo/server/server_test.go.
1. Using `c.Write()` with `6*1024*1024` bytes in `g.OnOpen()`, the left bytes will use `c.modWrite() --> epoll_ctl_mod` to write.
But in https://github.com/lesismal/nbio/blob/master/poller_epoll.go#L66-L83 use `p.g.onOpen() --> c.modWrite() --> epoll_ctl_mod` is before `g.addRead() --> epoll_ctl_add`，so that epoll will return error `ENOENT(2)` means using epoll_ctl_mod before epoll_ctl_add.
The epoll_ctl_mod error is not handled and the program will be stuck(never restore), client will never receive left bytes.
2. Operating `connsUnix []*Conn` without mutex.
In `poller.go`, `addConn()` and `getConn()` are not protected with mutex.When `ReadWriteLoop` calls `getConn()` may get nil conn sometimes, so that the program will also be stuck(never restore).Maybe it can use RWMutex to optimize.