### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build_bsd.yml
+++ b/.github/workflows/build_bsd.yml
@@ -36,6 +36,6 @@ jobs:
           go get -u github.com/lesismal/nbio/...
           ulimit -n 30000
           go env
-          echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: go test
         run: go test -covermode=atomic -timeout 60s -coverprofile="./coverage"

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -36,6 +36,6 @@ jobs:
           go get -u github.com/lesismal/nbio/...
           ulimit -n 30000
           go env
-          echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: go test
         run: go test -covermode=atomic -timeout 60s -coverprofile="./coverage"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -35,7 +35,7 @@ jobs:
           printf "\n\ngo environment:\n\n"
           go get -u github.com/lesismal/nbio/...
           go env
-          echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: go test
         run: go test -covermode=atomic -timeout 60s -coverprofile="./coverage"
       - name: update code coverage report


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


