### PR TITLE
Add error log for poller

### DIFF
--- a/poller_epoll.go
+++ b/poller_epoll.go
@@ -171,6 +171,7 @@ func (p *poller) readWriteLoop() {
 	for !p.shutdown {
 		n, err := syscall.EpollWait(p.epfd, events, msec)
 		if err != nil && !errors.Is(err, syscall.EINTR) {
+			logging.Error("NBIO[%v][%v_%v] EpollWait failed: %v, exit...", p.g.Name, p.pollType, p.index, err)
 			return
 		}
 

--- a/poller_kqueue.go
+++ b/poller_kqueue.go
@@ -245,6 +245,7 @@ func (p *poller) readWriteLoop() {
 		p.mux.Unlock()
 		n, err := syscall.Kevent(p.kfd, changes, events, nil)
 		if err != nil && !errors.Is(err, syscall.EINTR) {
+			logging.Error("NBIO[%v][%v_%v] Kevent failed: %v, exit...", p.g.Name, p.pollType, p.index, err)
 			return
 		}
 


### PR DESCRIPTION
In the poller's readWriteLoop, if there were errors when getting events, the readWriteLoop will exit without any indications, and the poller will stop working. 

In my case, I've encountered an error(no such file or directory) using syscall.Kevent, which cost me half a day to find the problem. 

Thus, adding a log will help all developers dealing this kind of situation. 