### PR TITLE
feat: update MaxWriteBufferSize comment  and MaxWriteBufferSize default check

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -23,7 +23,7 @@ const (
 	DefaultReadBufferSize = 1024 * 64
 
 	// DefaultMaxWriteBufferSize .
-	DefaultMaxWriteBufferSize = 1024 * 1024
+	DefaultMaxWriteBufferSize = 0
 
 	// DefaultMaxConnReadTimesPerEventLoop .
 	DefaultMaxConnReadTimesPerEventLoop = 3
@@ -67,8 +67,8 @@ type Config struct {
 	// ReadBufferSize represents buffer size for reading, it's set to 64k by default.
 	ReadBufferSize int
 
-	// MaxWriteBufferSize represents max write buffer size for Conn, it's set to 1m by default.
-	// if the connection's Send-Q is full and the data cached by nbio is
+	// MaxWriteBufferSize represents max write buffer size for Conn, 0 by default, represents no limit for writeBuffer
+	// if MaxWriteBufferSize is set greater than to 0, and the connection's Send-Q is full and the data cached by nbio is
 	// more than MaxWriteBufferSize, the connection would be closed by nbio.
 	MaxWriteBufferSize int
 

--- a/engine_std.go
+++ b/engine_std.go
@@ -137,6 +137,9 @@ func NewEngine(conf Config) *Engine {
 	if conf.ReadBufferSize <= 0 {
 		conf.ReadBufferSize = DefaultReadBufferSize
 	}
+	if conf.MaxWriteBufferSize < 0 {
+		conf.MaxWriteBufferSize = DefaultMaxWriteBufferSize
+	}
 	if conf.Listen == nil {
 		conf.Listen = net.Listen
 	}

--- a/engine_unix.go
+++ b/engine_unix.go
@@ -270,6 +270,9 @@ func NewEngine(conf Config) *Engine {
 	if conf.ReadBufferSize <= 0 {
 		conf.ReadBufferSize = DefaultReadBufferSize
 	}
+	if conf.MaxWriteBufferSize < 0 {
+		conf.MaxWriteBufferSize = DefaultMaxWriteBufferSize
+	}
 	if conf.MaxConnReadTimesPerEventLoop <= 0 {
 		conf.MaxConnReadTimesPerEventLoop = DefaultMaxConnReadTimesPerEventLoop
 	}

--- a/nbhttp/engine.go
+++ b/nbhttp/engine.go
@@ -119,8 +119,8 @@ type Config struct {
 	// ReadBufferSize represents buffer size for reading, it's set to 64k by default.
 	ReadBufferSize int
 
-	// MaxWriteBufferSize represents max write buffer size for Conn, it's set to 1m by default.
-	// if the connection's Send-Q is full and the data cached by nbio is
+	// MaxWriteBufferSize represents max write buffer size for Conn, 0 by default, represents no limit for writeBuffer
+	// if MaxWriteBufferSize is set greater than to 0, and the connection's Send-Q is full and the data cached by nbio is
 	// more than MaxWriteBufferSize, the connection would be closed by nbio.
 	MaxWriteBufferSize int
 


### PR DESCRIPTION
hello，i have read the talk in [issues 264](https://github.com/lesismal/nbio/issues/264)，but I found comment and check for `MaxWriteBufferSize ` may be not right？I have done follow things。

1. update outdated comment for `MaxWriteBufferSize`
2. set `DefaultMaxWriteBufferSize` 0 by default
3. add negative number check for `MaxWriteBufferSize` in `NewEngine()`
