### PR TITLE
perf: improve the performance of sending data

### DIFF
--- a/poller_epoll.go
+++ b/poller_epoll.go
@@ -291,6 +291,10 @@ func (p *poller) readWriteLoop() {
 						} else {
 							g.onRead(c)
 						}
+
+						if len(c.writeList) > 0 {
+							c.flush()
+						}
 					}
 
 					if ev.Events&epollEventsError != 0 {

--- a/poller_kqueue.go
+++ b/poller_kqueue.go
@@ -199,6 +199,10 @@ func (p *poller) readWrite(ev *syscall.Kevent_t) {
 				p.g.onRead(c)
 			}
 
+			if len(c.writeList) > 0 {
+				c.flush()
+			}
+
 			if ev.Flags&syscall.EV_EOF != 0 {
 				if c.onConnected == nil {
 					c.flush()


### PR DESCRIPTION
When data reading occurs, there is a high probability of data writeback generated in the `OnData`.
At this time, it is not necessary to wait for the registration write event callback to immediately perform the write operation, which can improve the performance of sending data.

benchmark use https://github.com/lesismal/go-websocket-benchmark

### BEFORE
```
----------------------------------------------------------------------------------------------------
20240523 22:34.41.956 [BenchEcho] Report

|    Framework     |  TPS   |  EER   |   Min   |   Avg   |   Max    |  TP50   |  TP75   |  TP90   |  TP95   |  TP99   | Used  |  Total  | Success | Failed | Conns | Concurrency | Payload | CPU Min | CPU Avg | CPU Max | MEM Min | MEM Avg | MEM Max |
|     ---          |  ---   |  ---   |   ---   |   ---   |   ---    |   ---   |   ---   |   ---   |   ---   |   ---   |  ---  |   ---   |   ---   |  ---   |  ---  |     ---     |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |
| nbio_nonblocking | 687201 | 909.76 | 29.69us | 14.51ms | 183.09ms | 12.32ms | 14.93ms | 20.63ms | 22.74ms | 63.07ms | 2.91s | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   |  0.00   | 755.36  | 1189.81 | 76.83M  | 80.48M  | 84.12M  |
----------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------
20240523 22:34.41.962 [BenchRate] Report

|    Framework     | Duration | EchoEER | Packet Sent | Bytes Sent | Packet Recv | Bytes Recv | Conns | SendRate | Payload | CPU Min | CPU Avg | CPU Max | MEM Min | MEM Avg | MEM Max |
|     ---          |   ---    |   ---   |     ---     |    ---     |     ---     |    ---     |  ---  |   ---    |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |
| nbio_nonblocking |  10.00s  | 1575.93 |  18275930   |   17.43G   |  18275930   |   17.43G   | 10000 |   200    |  1024   |  0.00   | 1159.69 | 1327.80 | 124.71M | 137.38M | 152.60M |
----------------------------------------------------------------------------------------------------
```

### AFTER
```
----------------------------------------------------------------------------------------------------
20240523 22:39.11.089 [BenchEcho] Report

|    Framework     |  TPS   |  EER   |   Min   |   Avg   |   Max    |  TP50   |  TP75   |  TP90   |  TP95   |  TP99   | Used  |  Total  | Success | Failed | Conns | Concurrency | Payload | CPU Min | CPU Avg | CPU Max | MEM Min | MEM Avg | MEM Max |
|     ---          |  ---   |  ---   |   ---   |   ---   |   ---    |   ---   |   ---   |   ---   |   ---   |   ---   |  ---  |   ---   |   ---   |  ---   |  ---  |     ---     |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |
| nbio_nonblocking | 707134 | 968.17 | 23.30us | 14.09ms | 101.21ms | 12.52ms | 15.67ms | 20.39ms | 21.32ms | 23.33ms | 2.83s | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   |  0.00   | 730.39  | 1209.78 | 91.67M  | 94.35M  | 97.02M  |
----------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------
20240523 22:39.11.096 [BenchRate] Report

|    Framework     | Duration | EchoEER | Packet Sent | Bytes Sent | Packet Recv | Bytes Recv | Conns | SendRate | Payload | CPU Min | CPU Avg | CPU Max | MEM Min | MEM Avg | MEM Max |
|     ---          |   ---    |   ---   |     ---     |    ---     |     ---     |    ---     |  ---  |   ---    |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |
| nbio_nonblocking |  10.00s  | 1419.24 |  18467060   |   17.61G   |  18375638   |   17.52G   | 10000 |   200    |  1024   | 1279.64 | 1294.75 | 1308.90 | 136.39M | 145.51M | 151.48M |
----------------------------------------------------------------------------------------------------
```

