### PR TITLE
Fix 'go test -cover' by reducing alignedindexes to 1<<16

### DIFF
--- a/mempool/aligned_allocator.go
+++ b/mempool/aligned_allocator.go
@@ -12,10 +12,10 @@ var (
 
 const (
 	minAlignedBufferSizeBits = 5
-	maxAlignedBufferSizeBits = 16
+	maxAlignedBufferSizeBits = 15
 	minAlignedBufferSize     = 1 << minAlignedBufferSizeBits                           // 32
 	minAlignedBufferSizeMask = minAlignedBufferSize - 1                                // 31
-	maxAlignedBufferSize     = (1 << maxAlignedBufferSizeBits) - 1                     // 64k
+	maxAlignedBufferSize     = (1 << maxAlignedBufferSizeBits)                         // 64k
 	alignedPoolBucketNum     = maxAlignedBufferSizeBits - minAlignedBufferSizeBits + 1 // 12
 )
 

--- a/mempool/aligned_allocator.go
+++ b/mempool/aligned_allocator.go
@@ -15,7 +15,7 @@ const (
 	maxAlignedBufferSizeBits = 16
 	minAlignedBufferSize     = 1 << minAlignedBufferSizeBits                           // 32
 	minAlignedBufferSizeMask = minAlignedBufferSize - 1                                // 31
-	maxAlignedBufferSize     = 1 << maxAlignedBufferSizeBits                           // 64k
+	maxAlignedBufferSize     = (1 << maxAlignedBufferSizeBits) - 1                     // 64k
 	alignedPoolBucketNum     = maxAlignedBufferSizeBits - minAlignedBufferSizeBits + 1 // 12
 )
 

--- a/mempool/aligned_allocator.go
+++ b/mempool/aligned_allocator.go
@@ -15,7 +15,7 @@ const (
 	maxAlignedBufferSizeBits = 15
 	minAlignedBufferSize     = 1 << minAlignedBufferSizeBits                           // 32
 	minAlignedBufferSizeMask = minAlignedBufferSize - 1                                // 31
-	maxAlignedBufferSize     = 1 << maxAlignedBufferSizeBits                           // 64k
+	maxAlignedBufferSize     = 1 << maxAlignedBufferSizeBits                           // 32k
 	alignedPoolBucketNum     = maxAlignedBufferSizeBits - minAlignedBufferSizeBits + 1 // 12
 )
 

--- a/mempool/aligned_allocator.go
+++ b/mempool/aligned_allocator.go
@@ -15,7 +15,7 @@ const (
 	maxAlignedBufferSizeBits = 15
 	minAlignedBufferSize     = 1 << minAlignedBufferSizeBits                           // 32
 	minAlignedBufferSizeMask = minAlignedBufferSize - 1                                // 31
-	maxAlignedBufferSize     = (1 << maxAlignedBufferSizeBits)                         // 64k
+	maxAlignedBufferSize     = 1 << maxAlignedBufferSizeBits                           // 64k
 	alignedPoolBucketNum     = maxAlignedBufferSizeBits - minAlignedBufferSizeBits + 1 // 12
 )
 


### PR DESCRIPTION
Issue when using 'go test -cover'. I see no impact in reducing the aligned buffer size by one. The actual problem is the alignedIndexes is greater than 1 << 16 causing this bug to happen when testing with coverage.

Issue raised with the golang developer team here https://github.com/golang/go/issues/73495