### PR TITLE
去掉去性能没有影响的代码

### DIFF
--- a/poller_epoll.go
+++ b/poller_epoll.go
@@ -244,12 +244,12 @@ func (p *poller) readWriteLoop() {
 			return
 		}
 
-		if n <= 0 {
-			msec = -1
-			// runtime.Gosched()
-			continue
-		}
-		msec = 20
+		// if n <= 0 {
+		// msec = -1
+		// runtime.Gosched()
+		// continue
+		// }
+		// msec = 20
 
 		for _, ev := range events[:n] {
 			fd := int(ev.Fd)


### PR DESCRIPTION
修改之前

A 6900hx机器数据
sec: 476, recv-count: 260486422, send-count:260486407 recv-tps: 547240, send-tps: 547240

B 6900hx机器数据
sec: 150, recv-count: 86958496, send-count:86958482 recv-tps: 579723, send-tps: 579723

修改之后
A 6900hx机器数据
sec: 283, recv-count: 153606508, send-count:153606492 recv-tps: 542779, send-tps: 542779

B 6900hx机器数据
sec: 150, recv-count: 87004344, send-count:87004336 recv-tps: 580028, send-tps: 580028

A机器散热不太好，空负载第一次跑数据好点，第二次数据低点。B机器散热好，可以发现两次数据接近