### PR TITLE
Add OnWriteSuccess callback to Conn for successful writes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -259,3 +259,10 @@ func (c *Conn) execute(job func()) {
 		}
 	})
 }
+
+// OnWriteSuccess registers callback for successfully written data
+//
+//go:norace
+func (c *Conn) OnWriteSuccess(h func(conn *Conn, data []byte)) {
+	c.onWriteSuccess = h
+}


### PR DESCRIPTION
This branch introduces a per-connection callback, OnWriteSuccess, which is called whenever data is successfully written to the underlying socket. I was looking for a way to know when each []byte is written and OnWrittenSize didnt seem like it would work as it is global, being on Engine.