### PR TITLE
Handle non-recoverable errors in lmux listener loop

### DIFF
--- a/lmux/lmux.go
+++ b/lmux/lmux.go
@@ -90,7 +90,9 @@ func (lm *ListenerMux) Start() {
 						}
 						listenerA.chEvent <- event{err: err, conn: c}
 						listenerB.chEvent <- event{err: err, conn: c}
-						// return
+						
+						// Exit the loop after a non recoverable error
+						return
 					}
 					continue
 				}


### PR DESCRIPTION
Exit the loop after a non-recoverable error instead of continuing.

We encountered a large volume of logs like:

```
2026/04/09 22:18:28.848 [ERR] Accept failed: accept tcp [::]:8081: use of closed network connection, exit...
```

and narrowed it down to this code. 



Looking at the code more closely, the issue is clear. In `lmux/lmux.go`, when a non-timeout error occurs, the error is logged but the loop **does not break or return** — it hits `continue` and calls `Accept()` again on the already-closed listener, which immediately fails again, creating an infinite spam loop.

```go name=lmux/lmux.go url=https://github.com/lesismal/nbio/blob/7a4cc550494ec24522b979011f9a92874524dc94/lmux/lmux.go#L79-L95
for !lm.shutdown {
    c, err := l.Accept()
    if err != nil {
        var ne net.Error
        if ok := errors.As(err, &ne); ok && ne.Timeout() {
            logging.Error("Accept failed: timeout error, retrying...")
            time.Sleep(time.Second / 20)
        } else {
            if !lm.shutdown {
                logging.Error("Accept failed: %v, exit...", err)
            }
            listenerA.chEvent <- event{err: err, conn: c}
            listenerB.chEvent <- event{err: err, conn: c}
            // return   <--- commented out!
        }
        continue  // <--- loops back immediately, Accept() fails again instantly
    }
    ...
}
```

The `return` is **commented out** on line 93, and there's no `break`, `time.Sleep`, or any other back-off. So once the listener is closed:

1. `Accept()` fails instantly with "use of closed network connection"
2. It's not a timeout error, so it falls into the `else` branch
3. The error is logged
4. `continue` loops back to `Accept()` which fails instantly again
5. Repeat forever — a hot loop spamming logs

The poller-based acceptor loops (`poller_std.go`, `poller_epoll.go`, `poller_kqueue.go`) have a similar structure but they at least break out when `p.shutdown` is set by `stop()`. The `ListenerMux` has a race between `lm.shutdown` being set and the listener being closed in `Stop()`, but more critically, the `return` that would exit the loop is commented out.
