### PR TITLE
updated body.Read to protect against data races on connection close

### DIFF
--- a/nbhttp/body.go
+++ b/nbhttp/body.go
@@ -31,13 +31,36 @@ type BodyReader struct {
 //
 //go:norace
 func (br *BodyReader) Read(p []byte) (int, error) {
+	// Close() may run while a handler (e.g. json.Decoder) is still reading.
+	if br.closed {
+		return 0, io.EOF
+	}
 	need := len(p)
 	if br.left <= 0 {
 		return 0, io.EOF
 	}
 	ncopy := 0
 	for ncopy < need && br.left > 0 {
+		if len(br.buffers) == 0 {
+			// left tracks bytes not yet copied out; buffers holds the backing
+			// slices. When they diverge (pool reuse, Close during Read, or
+			// zero-length head buffers), indexing buffers[0] panics.
+			br.left = 0
+			if ncopy > 0 {
+				return ncopy, nil
+			}
+			return 0, io.EOF
+		}
 		pbuf := br.buffers[0]
+		if br.index >= len(*pbuf) {
+			// Drop exhausted head buffers without decrementing left; those
+			// bytes were already accounted for when the buffer was consumed.
+			br.engine.BodyAllocator.Free(pbuf)
+			br.buffers[0] = nil
+			br.buffers = br.buffers[1:]
+			br.index = 0
+			continue
+		}
 		nc := copy(p[ncopy:], (*pbuf)[br.index:])
 		if nc+br.index >= len(*pbuf) {
 			br.engine.BodyAllocator.Free(pbuf)
@@ -66,6 +89,11 @@ func (br *BodyReader) Close() error {
 			br.engine.BodyAllocator.Free(b)
 		}
 	}
+	// Previously only freed backing memory; left/index/buffers were left
+	// stale, so a concurrent or subsequent Read could panic on buffers[0].
+	br.buffers = nil
+	br.left = 0
+	br.index = 0
 	// *br = emptyBodyReader
 	// bodyReaderPool.Put(br)
 	return nil
@@ -163,6 +191,12 @@ func (br *BodyReader) append(data []byte) error {
 //go:norace
 func NewBodyReader(engine *Engine) *BodyReader {
 	br := bodyReaderPool.Get().(*BodyReader)
+	// Reset all fields on pool Get so stale left/buffers
+	// from a previous request don't leak through.
+	br.index = 0
+	br.left = 0
+	br.buffers = nil
+	br.closed = false
 	br.engine = engine
 	return br
 }

--- a/nbhttp/body_test.go
+++ b/nbhttp/body_test.go
@@ -24,9 +24,9 @@ func TestBodyReaderPool(t *testing.T) {
 		}
 		buf = make([]byte, 10)
 		pbuf = &buf
-		br2.buffers = append(br.buffers, pbuf)
+		br2.buffers = append(br2.buffers, pbuf)
 		*br2 = emptyBodyReader
-		bodyReaderPool.Put(br)
+		bodyReaderPool.Put(br2)
 	}
 }
 
@@ -78,4 +78,59 @@ func TestBodyReader(t *testing.T) {
 		t.Fatalf("!bytes.Equal(allBytes, body2)")
 	}
 	_ = br2.Close()
+}
+
+func TestBodyReaderReadAfterClose(t *testing.T) {
+	engine := NewEngine(Config{
+		BodyAllocator: mempool.NewAligned(),
+	})
+	br := NewBodyReader(engine)
+	data := []byte("hello")
+	if err := br.append(data); err != nil {
+		t.Fatalf("append failed: %v", err)
+	}
+	if err := br.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+	buf := make([]byte, 8)
+	n, err := br.Read(buf)
+	if n != 0 || err != io.EOF {
+		t.Fatalf("Read after Close = (%d, %v), want (0, EOF)", n, err)
+	}
+}
+
+func TestBodyReaderLeftWithoutBuffers(t *testing.T) {
+	engine := NewEngine(Config{
+		BodyAllocator: mempool.NewAligned(),
+	})
+	br := NewBodyReader(engine)
+	br.left = 10
+	br.buffers = nil
+	buf := make([]byte, 8)
+	n, err := br.Read(buf)
+	if n != 0 || err != io.EOF {
+		t.Fatalf("Read with left>0 and no buffers = (%d, %v), want (0, EOF)", n, err)
+	}
+	if br.left != 0 {
+		t.Fatalf("left = %d, want 0", br.left)
+	}
+}
+
+func TestBodyReaderPooledReuse(t *testing.T) {
+	engine := NewEngine(Config{
+		BodyAllocator: mempool.NewAligned(),
+	})
+	br := NewBodyReader(engine)
+	if err := br.append([]byte("x")); err != nil {
+		t.Fatalf("append failed: %v", err)
+	}
+	_ = br.Close()
+	*br = emptyBodyReader
+	bodyReaderPool.Put(br)
+
+	br2 := NewBodyReader(engine)
+	if br2.left != 0 || br2.index != 0 || br2.buffers != nil || br2.closed {
+		t.Fatalf("pooled BodyReader not reset: left=%d index=%d buffers=%v closed=%v",
+			br2.left, br2.index, br2.buffers, br2.closed)
+	}
 }


### PR DESCRIPTION
We saw this error 

```
2026/06/22 16:21:18.809 [ERR] conn execute failed: runtime error: index out of range [0] with length 0
goroutine 319520437 [running]:
github.com/lesismal/nbio.(*Conn).Execute.(*Conn).execute.func1.1.1()
	/go/pkg/mod/github.com/lesismal/nbio@v1.6.9/conn.go:234 +0x6d
panic({0x14cbda0?, 0x40a4c3e5e00?})
	/usr/local/go/src/runtime/panic.go:860 +0x13a
github.com/lesismal/nbio/nbhttp.(*BodyReader).Read(0x40a4c282e40, {0x40a4c426c00, 0x200, 0x200})
	/go/pkg/mod/github.com/lesismal/nbio@v1.6.9/nbhttp/body.go:40 +0x20f
encoding/json.(*Decoder).refill(0x40a4c4fc640)
	/usr/local/go/src/encoding/json/stream.go:167 +0x188
encoding/json.(*Decoder).readValue(0x40a4c4fc640)
	/usr/local/go/src/encoding/json/stream.go:142 +0x85
encoding/json.(*Decoder).Decode(0x40a4c4fc640, {0x13184e0, 0x40a4ea05800})
	/usr/local/go/src/encoding/json/stream.go:65 +0x75
github.com/app/events.ParsePublishMessagesFromJson({0x7f7bbec5e348, 0x40a4c282e40})
	/app/events/event_util.go:29 +0x9d
github.com/app/api.(*Worker).registerNonSubscriberRoutes.publishHandler.func2({0x1641100, 0x40a4c4b2f00}, 0x40a4c4fc500)
	/app/api/publish_handler.go:15 +0x69
net/http.HandlerFunc.ServeHTTP(0x40a468e1440?, {0x1641100?, 0x40a4c4b2f00?}, 0x40a46210808?)
	/usr/local/go/src/net/http/server.go:2286 +0x29
net/http.(*ServeMux).ServeHTTP(0x1?, {0x1641100, 0x40a4c4b2f00}, 0x40a4c4fc500)
	/usr/local/go/src/net/http/server.go:2828 +0x1c7
github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.TraceAndServe({0x16370c0, 0x40a468e1440}, {0x1640bd0?, 0x40a54750690?}, 0x40a469c6e18?, 0x15b5280?)
	/go/pkg/mod/github.com/!data!dog/dd-trace-go/contrib/net/http/v2@v2.8.2/internal/wrap/trace.go:23 +0x82
github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.(*ServeMux).ServeHTTP(0x40a46940b50, {0x1640bd0, 0x40a54750690}, 0x40a4c2abcc0)
	/go/pkg/mod/github.com/!data!dog/dd-trace-go/contrib/net/http/v2@v2.8.2/internal/wrap/mux.go:85 +0x2fc
github.com/app/api.(*Worker).Run.(*Worker).Run.DeferMiddleware.func13.func14({0x1640bd0?, 0x40a54750690?}, 0x40a4c2abcc0?)
	/app/middleware/defer_middleware.go:20 +0x7f
net/http.HandlerFunc.ServeHTTP(0x28?, {0x1640bd0?, 0x40a54750690?}, 0x11da685?)
	/usr/local/go/src/net/http/server.go:2286 +0x29
github.com/lesismal/nbio/nbhttp.(*ServerProcessor).OnComplete.func1()
	/go/pkg/mod/github.com/lesismal/nbio@v1.6.9/nbhttp/processor.go:281 +0x4c
github.com/lesismal/nbio.(*Conn).Execute.(*Conn).execute.func1.1(0x40a469c6f78?)
	/go/pkg/mod/github.com/lesismal/nbio@v1.6.9/conn.go:241 +0x33
github.com/lesismal/nbio.(*Conn).Execute.(*Conn).execute.func1()
	/go/pkg/mod/github.com/lesismal/nbio@v1.6.9/conn.go:242 +0x4a
github.com/lesismal/nbio/taskpool.New.func1(0x40a469c6fd0?)
	/go/pkg/mod/github.com/lesismal/nbio@v1.6.9/taskpool/taskpool.go:99 +0x33
github.com/lesismal/nbio/taskpool.(*TaskPool).fork.func1()
	/go/pkg/mod/github.com/lesismal/nbio@v1.6.9/taskpool/taskpool.go:31 +0x5e
created by github.com/lesismal/nbio/taskpool.(*TaskPool).fork in goroutine 139
	/go/pkg/mod/github.com/lesismal/nbio@v1.6.9/taskpool/taskpool.go:29 +0xc5
```

and a json decoder parse error

```
invalid character 'H' looking for beginning of value
```

After some debugging, we determined that the bug was upstream in this body.go class. Added some safeguards to the `Read` method and some stale protections when closing bodies.